### PR TITLE
Update TPROC-C stock counters and customer payment/delivery counters

### DIFF
--- a/docs/tproc_spec_check.md
+++ b/docs/tproc_spec_check.md
@@ -1,0 +1,141 @@
+# HammerDB TPROC-C / TPROC-H specification check (cross-database code review)
+
+This note captures a source-level review of HammerDB TPROC-C and TPROC-H implementations for:
+- Oracle
+- SQL Server
+- Db2
+- MySQL
+- MariaDB
+- PostgreSQL
+
+## Executive summary
+
+- **Generally, the implementations are good**: all reviewed engines implement the canonical TPROC-C transaction set (`neword`, `delivery`, `payment`, `ostat`, `slev`) and include expected Payment bad-credit handling logic.
+- **Good credit vs bad credit is not omitted**:
+  - Load/build paths assign both `GC` and `BC` customer credit types.
+  - Payment logic branches specifically on `BC`, updating `c_data` for bad-credit customers and doing balance-only update otherwise.
+- **Common cross-engine caveat**: New-Order stock updates are broadly implemented as `s_quantity` updates only (despite stock tables carrying `s_ytd`, `s_order_cnt`, `s_remote_cnt`). This is the main strict-spec gap observed.
+
+---
+
+## 1) TPROC-C stored procedure coverage (all reviewed DBs)
+
+All six reviewed engines include the five TPROC-C transactions in their TPROC-C implementations:
+- `neword`
+- `delivery`
+- `payment`
+- `ostat`
+- `slev`
+
+(See each `*oltp.tcl` file for the CREATE PROCEDURE blocks.)
+
+## 2) Good credit / bad credit (`GC` / `BC`) comment resolution
+
+### Finding
+The comment that HammerDB omits good/bad credit is **not supported** by code.
+
+### Evidence pattern seen across engines
+1. **Customer load/build assigns both values**
+   - Typical pattern: random assignment of `c_credit` to `"GC"` or `"BC"` during customer data generation.
+2. **Payment explicitly tests bad credit**
+   - Typical pattern: `IF p_c_credit = 'BC'` (or equivalent `CASE WHEN c_credit <> 'BC'`) then prepend/maintain `c_data` logic for BC customers.
+
+So, both customer classes are present and handled.
+
+## 3) Cross-engine caveat: stock counters in New-Order
+
+### Finding
+Across the reviewed engines, New-Order stock maintenance is commonly implemented with `s_quantity` updates only, while stock schema includes:
+- `s_ytd`
+- `s_order_cnt`
+- `s_remote_cnt`
+
+### Why this matters
+For strict TPC-C semantic alignment, New-Order stock updates are usually expected to maintain those counters in addition to quantity.
+
+---
+
+## 4) Per-engine quick notes
+
+### Oracle (`src/oracle/oraoltp.tcl`)
+- Has `GC`/`BC` customer generation and `IF p_c_credit = 'BC'` branch in Payment.
+- New-Order stock update observed as quantity update.
+
+### SQL Server (`src/mssqlserver/mssqlsoltp.tcl`)
+- Has `GC`/`BC` customer generation and Payment branch logic via `CASE WHEN c_credit <> 'BC'`.
+- Stock schema includes counters (`s_ytd`, `s_order_cnt`, `s_remote_cnt`).
+
+### Db2 (`src/db2/db2oltp.tcl`)
+- Has `GC`/`BC` customer generation and `IF p_c_credit = 'BC'` in Payment.
+- New-Order stock update uses quantity-change expression in `UPDATE STOCK ... SET s_quantity = ...`.
+
+### MySQL (`src/mysql/mysqloltp.tcl`)
+- Has `GC`/`BC` customer generation and `IF p_c_credit = 'BC'` in Payment.
+- Stored-proc and non-stored New-Order paths both show quantity-only stock updates.
+
+### MariaDB (`src/mariadb/mariaoltp.tcl`)
+- Has `GC`/`BC` customer generation and `IF p_c_credit = 'BC'` in Payment.
+- Stored-proc and non-stored New-Order paths show quantity-only stock updates.
+
+### PostgreSQL (`src/postgresql/pgoltp.tcl`)
+- Has `GC`/`BC` customer generation and `IF p_c_credit = 'BC'` in Payment.
+- New-Order stock update observed as quantity update.
+
+---
+
+## 5) TPROC-H scope note
+
+TPROC-H in HammerDB is implemented as driver/query/refresh logic (and not as a required set of DB-resident stored procedures in the same way as TPROC-C). For MySQL-family paths, refresh functions match RF1/RF2 style orchestration and there is a separate non-standard “Cloud Analytic TPCH” workload variant.
+
+---
+
+## 6) Recommendation
+
+If you want strict TPROC-C semantic alignment across all engines, prioritize adding stock-counter maintenance in New-Order:
+- `s_ytd = s_ytd + ol_quantity`
+- `s_order_cnt = s_order_cnt + 1`
+- `s_remote_cnt = s_remote_cnt + 1` for remote supplier warehouse lines.
+
+Given the current codebase, the single biggest cross-engine semantic delta is this stock-counter behavior—not omission of good/bad credit handling.
+
+---
+
+## 7) Example: New-Order stock-counter maintenance
+
+Below is a concrete pattern showing how to extend the existing quantity update so it also maintains stock counters.
+
+### Generic SQL pattern
+
+```sql
+UPDATE stock
+SET s_quantity   = CASE
+                     WHEN s_quantity > :ol_quantity
+                     THEN s_quantity - :ol_quantity
+                     ELSE s_quantity - :ol_quantity + 91
+                   END,
+    s_ytd        = s_ytd + :ol_quantity,
+    s_order_cnt  = s_order_cnt + 1,
+    s_remote_cnt = s_remote_cnt + CASE
+                                    WHEN :ol_supply_w_id <> :home_w_id THEN 1
+                                    ELSE 0
+                                  END
+WHERE s_i_id = :ol_i_id
+  AND s_w_id = :ol_supply_w_id;
+```
+
+### MySQL/MariaDB stored-procedure style example
+
+```sql
+UPDATE stock
+SET s_quantity = no_s_quantity,
+    s_ytd = s_ytd + no_ol_quantity,
+    s_order_cnt = s_order_cnt + 1,
+    s_remote_cnt = s_remote_cnt + IF(no_ol_supply_w_id <> no_w_id, 1, 0)
+WHERE s_i_id = no_ol_i_id
+  AND s_w_id = no_ol_supply_w_id;
+```
+
+### Notes
+- `s_order_cnt` increments for every order line processed.
+- `s_remote_cnt` increments only when supply warehouse differs from home warehouse.
+- Keep this update in the same transaction scope as the rest of New-Order row changes.

--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -109,10 +109,13 @@ proc CreateStoredProcs { db_handle } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM NEW TABLE (UPDATE STOCK
-        SET s_quantity = CASE WHEN ( s_quantity > no_ol_quantity )
+        SET s_quantity = CASE WHEN ( s_quantity >= ( no_ol_quantity + 10 ) )
         THEN ( s_quantity - no_ol_quantity )
         ELSE ( s_quantity - no_ol_quantity + 91 )
-        END
+        END,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + CASE WHEN ( no_ol_supply_w_id <> no_w_id ) THEN 1 ELSE 0 END
         WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id
         ) AS US;
         SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
@@ -242,11 +245,11 @@ proc CreateStoredProcs { db_handle } {
         SET p_c_new_data = (TO_CHAR(p_c_id) || ' ' || TO_CHAR(p_c_d_id) || ' ' || TO_CHAR(p_c_w_id) || ' ' || TO_CHAR(p_d_id) || ' ' || TO_CHAR(p_w_id) || ' ' || VARCHAR_FORMAT(p_h_amount,'9999.99') || VARCHAR_FORMAT(timestamp,'YYYYMMDDHH24MISS') || h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -284,7 +287,7 @@ proc CreateStoredProcs { db_handle } {
         SET ol_delivery_d = tstamp
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id AND
         ol_w_id = d_w_id);
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         set deliv_data[loop_counter] = d_no_o_id;

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -124,13 +124,16 @@ proc CreateStoredProcs { maria_handler } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-        IF ( no_s_quantity > no_ol_quantity )
+        IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
         THEN
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity );
         ELSE
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity + 91 );
         END IF;
-        UPDATE stock SET s_quantity = no_s_quantity
+        UPDATE stock SET s_quantity = no_s_quantity,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + IF(no_ol_supply_w_id != no_w_id,1,0)
         WHERE s_i_id = no_ol_i_id
         AND s_w_id = no_ol_supply_w_id;
         SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
@@ -200,7 +203,7 @@ proc CreateStoredProcs { maria_handler } {
         FROM order_line
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
         AND ol_w_id = d_w_id;
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         SET deliv_data = CONCAT(d_d_id,' ',d_no_o_id,' ',timestamp);
@@ -314,11 +317,11 @@ proc CreateStoredProcs { maria_handler } {
         SET p_c_new_data = CONCAT(CAST(p_c_id AS CHAR),' ',CAST(p_c_d_id AS CHAR),' ',CAST(p_c_w_id AS CHAR),' ',CAST(p_d_id AS CHAR),' ',CAST(p_w_id AS CHAR),' ',CAST(FORMAT(p_h_amount,2) AS CHAR),CAST(timestamp AS CHAR),h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -1480,12 +1483,12 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
       set quantity_data_dist [ maria::sel $maria_handler "SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id" -flatlist ]
       set no_i_price [ lindex $price_name_data 0 ]
       set no_s_quantity [ lindex $quantity_data_dist 0 ]
-      if { $no_s_quantity > $no_ol_quantity } {
+      if { $no_s_quantity >= ($no_ol_quantity + 10) } {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity} ]
       } else {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity + 91} ]
       }
-      mariaexec $maria_handler "UPDATE stock SET s_quantity = $no_s_quantity WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
+      mariaexec $maria_handler "UPDATE stock SET s_quantity = $no_s_quantity, s_ytd = s_ytd + $no_ol_quantity, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + IF($no_ol_supply_w_id != $no_w_id,1,0) WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
       set no_ol_amount [ expr {($no_ol_quantity * $no_i_price * ( 1 + $no_w_tax + $no_d_tax ) * ( 1 - $no_c_discount ))} ]
       switch $no_d_id {
         1 { set no_ol_dist_info [ lindex $quantity_data_dist 2 ] }
@@ -1571,9 +1574,9 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
       set h_data [ concat $p_w_name $p_d_name ]
       set p_c_new_data [ concat p_c_id $p_c_id p_c_d_id $p_c_d_id p_c_w_id $p_c_w_id p_d_id $p_d_id p_w_id $p_w_id p_h_amount [ format %4.2f $p_h_amount ] h_date $h_date h_data $h_data ]
       set p_c_new_data [ string range [ concat $p_c_new_data $c_data ] 1 [ expr 500 - [ string length $p_c_new_data ] ] ]
-      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data' WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data', c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
     } else {
-      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
       set c_data ""
     }
     set h_data [ concat $p_w_name $p_d_name ]
@@ -1639,7 +1642,7 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
 	mariaexec $maria_handler "UPDATE orders SET o_carrier_id = $carrier_id WHERE o_id = $no_o_id AND o_d_id = $d_d_id AND o_w_id = $w_id"
 	mariaexec $maria_handler "UPDATE order_line SET ol_delivery_d = str_to_date($date,'%Y%m%d%H%i%s') WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id"
    	set d_ol_total [ list [ maria::sel $maria_handler "SELECT SUM(ol_amount) FROM order_line WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id" -list ]]
-	mariaexec $maria_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
+	mariaexec $maria_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
 	incr loop_counter
        	}
 	maria::commit $maria_handler

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -135,8 +135,11 @@ proc CreateStoredProcs { odbc imdb } {
             WHERE item.i_id = @no_ol_i_id
             UPDATE dbo.stock
             SET
-            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity > @no_ol_quantity)
+            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity >= (@no_ol_quantity + 10))
             THEN 0 ELSE 91 END,
+            s_ytd = s_ytd + @no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN (@no_ol_supply_w_id <> @no_w_id) THEN 1 ELSE 0 END,
             @no_s_data = s_data,
             @no_ol_dist_info =
             CASE @no_d_id
@@ -256,7 +259,7 @@ proc CreateStoredProcs { odbc imdb } {
             AND order_line.ol_d_id = @d_d_id
             AND order_line.ol_w_id = @d_w_id
             END
-            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total
+            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE customer.c_id = @d_c_id
             AND customer.c_d_id = @d_d_id
             AND customer.c_w_id = @d_w_id
@@ -358,6 +361,8 @@ proc CreateStoredProcs { odbc imdb } {
             UPDATE dbo.customer
             SET
             @p_c_balance = c_balance = c_balance - @p_h_amount,
+            c_ytd_payment = c_ytd_payment + @p_h_amount,
+            c_payment_cnt = c_payment_cnt + 1,
             c_data =
             CASE
             WHEN c_credit <> 'BC' THEN c_credit
@@ -683,8 +688,11 @@ proc CreateStoredProcs { odbc imdb } {
             WHERE item.i_id = @no_ol_i_id
             UPDATE dbo.stock
             SET
-            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity > @no_ol_quantity)
+            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity >= (@no_ol_quantity + 10))
             THEN 0 ELSE 91 END,
+            s_ytd = s_ytd + @no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN (@no_ol_supply_w_id <> @no_w_id) THEN 1 ELSE 0 END,
             @no_s_data = s_data,
             @no_ol_dist_info =
             CASE @no_d_id
@@ -801,7 +809,7 @@ proc CreateStoredProcs { odbc imdb } {
             AND order_line.ol_d_id = @d_d_id
             AND order_line.ol_w_id = @d_w_id
             END
-            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total
+            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE customer.c_id = @d_c_id
             AND customer.c_d_id = @d_d_id
             AND customer.c_w_id = @d_w_id
@@ -900,6 +908,8 @@ proc CreateStoredProcs { odbc imdb } {
             UPDATE dbo.customer
             SET
             @p_c_balance = c_balance = c_balance - @p_h_amount,
+            c_ytd_payment = c_ytd_payment + @p_h_amount,
+            c_payment_cnt = c_payment_cnt + 1,
             c_data =
             CASE
             WHEN c_credit <> 'BC' THEN c_credit

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -117,13 +117,16 @@ proc CreateStoredProcs { mysql_handler } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-        IF ( no_s_quantity > no_ol_quantity )
+        IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
         THEN
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity );
         ELSE
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity + 91 );
         END IF;
-        UPDATE stock SET s_quantity = no_s_quantity
+        UPDATE stock SET s_quantity = no_s_quantity,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + IF(no_ol_supply_w_id != no_w_id,1,0)
         WHERE s_i_id = no_ol_i_id
         AND s_w_id = no_ol_supply_w_id;
         SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
@@ -191,7 +194,7 @@ proc CreateStoredProcs { mysql_handler } {
         FROM order_line
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
         AND ol_w_id = d_w_id;
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         SET deliv_data = CONCAT(d_d_id,' ',d_no_o_id,' ',timestamp);
@@ -303,11 +306,11 @@ proc CreateStoredProcs { mysql_handler } {
         SET p_c_new_data = CONCAT(CAST(p_c_id AS CHAR),' ',CAST(p_c_d_id AS CHAR),' ',CAST(p_c_w_id AS CHAR),' ',CAST(p_d_id AS CHAR),' ',CAST(p_w_id AS CHAR),' ',CAST(FORMAT(p_h_amount,2) AS CHAR),CAST(timestamp AS CHAR),h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -1458,12 +1461,12 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
       set quantity_data_dist [ mysql::sel $mysql_handler "SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id" -flatlist ]
       set no_i_price [ lindex $price_name_data 0 ]
       set no_s_quantity [ lindex $quantity_data_dist 0 ]
-      if { $no_s_quantity > $no_ol_quantity } {
+      if { $no_s_quantity >= ($no_ol_quantity + 10) } {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity} ]
       } else {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity + 91} ]
       }
-      mysqlexec $mysql_handler "UPDATE stock SET s_quantity = $no_s_quantity WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
+      mysqlexec $mysql_handler "UPDATE stock SET s_quantity = $no_s_quantity, s_ytd = s_ytd + $no_ol_quantity, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + IF($no_ol_supply_w_id != $no_w_id,1,0) WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
       set no_ol_amount [ expr {($no_ol_quantity * $no_i_price * ( 1 + $no_w_tax + $no_d_tax ) * ( 1 - $no_c_discount ))} ]
       switch $no_d_id {
         1 { set no_ol_dist_info [ lindex $quantity_data_dist 2 ] }
@@ -1549,9 +1552,9 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
       set h_data [ concat $p_w_name $p_d_name ]
       set p_c_new_data [ concat p_c_id $p_c_id p_c_d_id $p_c_d_id p_c_w_id $p_c_w_id p_d_id $p_d_id p_w_id $p_w_id p_h_amount [ format %4.2f $p_h_amount ] h_date $h_date h_data $h_data ]
       set p_c_new_data [ string range [ concat $p_c_new_data $c_data ] 1 [ expr 500 - [ string length $p_c_new_data ] ] ]
-      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data' WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data', c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
     } else {
-      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
       set c_data ""
     }
     set h_data [ concat $p_w_name $p_d_name ]
@@ -1617,7 +1620,7 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
 	mysqlexec $mysql_handler "UPDATE orders SET o_carrier_id = $carrier_id WHERE o_id = $no_o_id AND o_d_id = $d_d_id AND o_w_id = $w_id"
 	mysqlexec $mysql_handler "UPDATE order_line SET ol_delivery_d = str_to_date($date,'%Y%m%d%H%i%s') WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id"
    	set d_ol_total [ list [ mysql::sel $mysql_handler "SELECT SUM(ol_amount) FROM order_line WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id" -list ]]
-	mysqlexec $mysql_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
+	mysqlexec $mysql_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
 	incr loop_counter
        	}
 	mysql::commit $mysql_handler

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -127,13 +127,16 @@ proc CreateStoredProcs { lda timesten num_part } {
             FROM item WHERE i_id = no_ol_i_id;
             SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
             INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-            IF ( no_s_quantity > no_ol_quantity )
+            IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
             THEN
             no_s_quantity := ( no_s_quantity - no_ol_quantity );
             ELSE
             no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
             END IF;
-            UPDATE stock SET s_quantity = no_s_quantity
+            UPDATE stock SET s_quantity = no_s_quantity,
+            s_ytd = s_ytd + no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN no_ol_supply_w_id != no_w_id THEN 1 ELSE 0 END
             WHERE s_i_id = no_ol_i_id
             AND s_w_id = no_ol_supply_w_id;
 
@@ -423,7 +426,7 @@ proc CreateStoredProcs { lda timesten num_part } {
                 FROM order_line
                 WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
                 AND ol_w_id = d_w_id;
-                UPDATE customer SET c_balance = c_balance + d_ol_total
+                UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
                 WHERE c_id = d_c_id AND c_d_id = d_d_id AND
                 c_w_id = d_w_id;
                 COMMIT;
@@ -471,7 +474,7 @@ proc CreateStoredProcs { lda timesten num_part } {
                 FROM order_line
                 WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
                 AND ol_w_id = d_w_id;
-                UPDATE customer SET c_balance = c_balance + d_ol_total
+                UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
                 WHERE c_id = d_c_id AND c_d_id = d_d_id AND
                 c_w_id = d_w_id;
                 COMMIT;
@@ -540,9 +543,8 @@ proc CreateStoredProcs { lda timesten num_part } {
 
             FORALL c IN 1.. ordcnt
             UPDATE customer
-            SET c_balance = c_balance + sums(c)
-            -- Added this in for the refactor but it's not in the original (although it should be) so I've removed it, to be true to the original
-            --, c_delivery_cnt = c_delivery_cnt + 1
+            SET c_balance = c_balance + sums(c),
+            c_delivery_cnt = c_delivery_cnt + 1
             WHERE c_w_id = d_w_id
             AND c_d_id = dist_id_array(c)
             AND c_id = order_c_id(c);
@@ -624,9 +626,9 @@ proc CreateStoredProcs { lda timesten num_part } {
         cust_rowid := row_id ((c_num + 1) / 2);
 
         UPDATE customer
-        SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
+        SET c_balance = c_balance - p_h_amount,
+        c_ytd_payment = c_ytd_payment + p_h_amount,
+        c_payment_cnt = c_payment_cnt + 1
         WHERE rowid = cust_rowid
         RETURNING c_id, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,
@@ -638,9 +640,9 @@ proc CreateStoredProcs { lda timesten num_part } {
         p_c_discount, p_c_balance;
         ELSE
         UPDATE customer
-        SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
+        SET c_balance = c_balance - p_h_amount,
+        c_ytd_payment = c_ytd_payment + p_h_amount,
+        c_payment_cnt = c_payment_cnt + 1
         WHERE c_id = p_c_id AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id
         RETURNING rowid, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -125,13 +125,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             FROM item WHERE i_id = no_ol_i_id;
             SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
             INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-            IF ( no_s_quantity > no_ol_quantity )
+            IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
             THEN
             no_s_quantity := ( no_s_quantity - no_ol_quantity );
             ELSE
             no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
             END IF;
-            UPDATE stock SET s_quantity = no_s_quantity
+            UPDATE stock SET s_quantity = no_s_quantity,
+            s_ytd = s_ytd + no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN no_ol_supply_w_id != no_w_id THEN 1 ELSE 0 END
             WHERE s_i_id = no_ol_i_id
             AND s_w_id = no_ol_supply_w_id;
 
@@ -217,7 +220,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             FROM order_line
             WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
             AND ol_w_id = d_w_id;
-            UPDATE customer SET c_balance = c_balance + d_ol_total
+            UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE c_id = d_c_id AND c_d_id = d_d_id AND
             c_w_id = d_w_id;
             DBMS_OUTPUT.PUT_LINE('D: ' || d_d_id || 'O: ' || d_no_o_id || 'time ' || tstamp);
@@ -330,11 +333,11 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             TO_CHAR(p_c_w_id) || ' ' || TO_CHAR(p_d_id) || ' ' || TO_CHAR(p_w_id) || ' ' || TO_CHAR(p_h_amount,'9999.99') || TO_CHAR(tstamp) || h_data);
             p_c_new_data := substr(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
             UPDATE customer
-            SET c_balance = p_c_balance, c_data = p_c_new_data
+            SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
             WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
             c_id = p_c_id;
             ELSE
-            UPDATE customer SET c_balance = p_c_balance
+            UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
             WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
             c_id = p_c_id;
             END IF;
@@ -548,13 +551,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -563,13 +569,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -578,13 +587,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -593,13 +605,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -608,13 +623,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -623,13 +641,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -638,13 +659,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -653,13 +677,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -668,13 +695,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -683,13 +713,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -887,6 +920,8 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 UPDATE customer
                 SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1,
                 c_data = substr ((p_c_id || ' ' ||
                 p_c_d_id || ' ' ||
                 p_c_w_id || ' ' ||
@@ -899,7 +934,9 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
                 ELSE
                 UPDATE customer
-                SET c_balance = p_c_balance - p_h_amount
+                SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1
                 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
                 END IF;
@@ -1085,13 +1122,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1100,13 +1140,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1115,13 +1158,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1130,13 +1176,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1145,13 +1194,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1160,13 +1212,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1175,13 +1230,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1190,13 +1248,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1205,13 +1266,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1220,13 +1284,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1434,6 +1501,8 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 UPDATE customer
                 SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1,
                 c_data = substr ((p_c_id || '' '' ||
                 p_c_d_id || '' '' ||
                 p_c_w_id || '' '' ||
@@ -1444,7 +1513,9 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_new_data;
                 ELSE
                 UPDATE customer
-                SET c_balance = p_c_balance - p_h_amount
+                SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1
                 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
                 RETURNING c_balance, '' '' INTO p_c_balance, p_c_new_data;
                 END IF;


### PR DESCRIPTION
### Motivation
- Bring HammerDB TPROC-C implementations closer to TPC-C semantics by maintaining stock counters and customer payment/delivery aggregates that were not consistently updated across engines.
- Capture a source-level cross-database review of TPROC-C/TPROC-H implementation differences and recommendations for strict semantic alignment.

### Description
- Add maintenance of stock counters in New-Order paths across multiple engines by updating `s_ytd`, `s_order_cnt`, and `s_remote_cnt` alongside `s_quantity`, and adjust the low-stock threshold condition to `s_quantity >= (ol_quantity + 10)` where applicable.
- Increment customer payment counters in Payment paths by updating `c_ytd_payment` and `c_payment_cnt` for all engines, and increment `c_delivery_cnt` in Delivery paths where delivery aggregates are computed.
- Update various engine-specific TCL stored-proc / non-stored-proc implementations (Oracle, SQL Server, Db2, MySQL, MariaDB, PostgreSQL) to apply the above changes and to align returned/aggregated order-line amount calculations in some set-based New-Order implementations.
- Add `docs/tproc_spec_check.md`, a cross-database review describing findings, the main semantic delta (stock counters), and recommended SQL patterns to implement strict TPROC-C alignment.

### Testing
- No automated tests were executed as part of this change; these are source-level stored-procedure and script changes that require running the HammerDB workload or DB-specific procedure deployment to validate runtime behavior.
- Recommend running the full HammerDB TPROC-C test harness and engine-specific SQL/PLSQL/TSQL syntax checks and integration tests after applying these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69919cd811e883249ae53a45f5ed78f0)