### PR TITLE
Add I/O metrics collection and charting support

### DIFF
--- a/agent/agent
+++ b/agent/agent
@@ -75,6 +75,17 @@ global agentlist
 Agent send [ lindex $agentlist 0 ] [lindex $agentlist 1 ] StatsOneLine [list $line ]
 }
 
+proc SendIOLine { iops mbps } {
+global agentlist
+set iops [format "%.2f" $iops]
+set mbps [format "%.2f" $mbps]
+foreach f $agentlist {
+    if {[catch {Agent send $f StatsOneLine [list [list IOSTAT $iops $mbps]]}]} {
+        # Ignore transient send errors; normal agent reconnection logic handles disconnects.
+    }
+}
+}
+
 proc lremove { list item {all ""} } {
   set index [lsearch -exact $list $item]
   if {$index == -1} { return $list }
@@ -471,7 +482,7 @@ puts "Error Sending Data: $b"
 }
 
 proc StartMetrics {} {
-global agentlist S cpu_model iswin sysinfo
+global agentlist S cpu_model iswin sysinfo io_metrics_running
 puts "Prepared CPU metrics for $cpu_model"
 #Discover system information before sending metrics
 if {$iswin} {
@@ -498,6 +509,8 @@ puts "Failed $b"
 puts "connection established"
                 }
 }
+set io_metrics_running 1
+after 2000 RunIOMetrics
 if {$iswin} {
     if {[file exists "mpstat.bat"]} {
         set fin [open "| mpstat.bat" r]
@@ -512,7 +525,96 @@ if {$iswin} {
     fconfigure $fin -blocking false
     fileevent $fin readable [list isReadable $fin] 
     vwait ::DONE
+    set io_metrics_running 0
     close $fin
+}
+
+proc RunIOMetrics {} {
+global iswin io_metrics_running
+if {![info exists io_metrics_running] || !$io_metrics_running} {
+    return
+}
+set iops 0.0
+set mbps 0.0
+if {$iswin} {
+    if {[catch {lassign [CollectIOMetricsWindows] iops mbps}]} {
+        set iops 0.0
+        set mbps 0.0
+    }
+} else {
+    if {[catch {set iom [CollectIOMetricsLinux]}]} {
+        set iom {}
+    }
+    if {[llength $iom] eq 2} {
+        lassign $iom iops mbps
+    }
+}
+if {[string is double -strict $iops] && [string is double -strict $mbps]} {
+    SendIOLine $iops $mbps
+}
+after 2000 RunIOMetrics
+}
+
+proc CollectIOMetricsLinux {} {
+    global io_last_time io_last_reads io_last_writes io_last_sectors
+    set now [clock milliseconds]
+    if {[catch {set fin [open /proc/diskstats r]}]} {
+        return {}
+    }
+    set reads 0
+    set writes 0
+    set sectors 0
+    while {[gets $fin line] >= 0} {
+        set fields [regexp -all -inline {\S+} $line]
+        if {[llength $fields] < 14} { continue }
+        set dev [lindex $fields 2]
+        if {[regexp {^(loop|ram|fd|sr|dm-|md)} $dev]} { continue }
+        set reads [expr {$reads + [lindex $fields 3]}]
+        set writes [expr {$writes + [lindex $fields 7]}]
+        set sectors [expr {$sectors + [lindex $fields 5] + [lindex $fields 9]}]
+    }
+    close $fin
+    if {![info exists io_last_time]} {
+        set io_last_time $now
+        set io_last_reads $reads
+        set io_last_writes $writes
+        set io_last_sectors $sectors
+        return {}
+    }
+    set dt [expr {($now - $io_last_time) / 1000.0}]
+    if {$dt <= 0} { return {} }
+    set diops [expr {(($reads - $io_last_reads) + ($writes - $io_last_writes)) / $dt}]
+    set dmbps [expr {(($sectors - $io_last_sectors) * 512.0 / 1048576.0) / $dt}]
+    set io_last_time $now
+    set io_last_reads $reads
+    set io_last_writes $writes
+    set io_last_sectors $sectors
+    if {$diops < 0} { set diops 0.0 }
+    if {$dmbps < 0} { set dmbps 0.0 }
+    return [list $diops $dmbps]
+}
+
+proc CollectIOMetricsWindows {} {
+    global io_pdh_query
+    if {![info exists io_pdh_query]} {
+        if {[catch {set io_pdh_query [twapi::pdh_system_performance_query disk_transfer_per_sec disk_bytes_per_sec]}]} {
+            return [list 0.0 0.0]
+        }
+        after 1000
+    }
+    catch {twapi::pdh_query_update $io_pdh_query}
+    if {[catch {set perf_data [twapi::pdh_query_get $io_pdh_query]}]} {
+        return [list 0.0 0.0]
+    }
+    set iops 0.0
+    set mbps 0.0
+    if {[dict exists $perf_data disk_transfer_per_sec]} {
+        set iops [dict get $perf_data disk_transfer_per_sec]
+    }
+    if {[dict exists $perf_data disk_bytes_per_sec]} {
+        set mbps [expr {[dict get $perf_data disk_bytes_per_sec] / 1048576.0}]
+    }
+    return [list $iops $mbps]
 }
 
 set agentlist ""

--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -107,7 +107,7 @@ namespace eval jobs {
         } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTCOUNT(jobid TEXT, counter INTEGER, metric TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBTCOUNT table in SQLite in-memory database : $message"
           return
-        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+        } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, iops REAL, mbps REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
           puts "Error creating JOBMETRIC table in SQLite in-memory database : $message"
           return
 	      } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, system_vendor TEXT, system_type TEXT, os_name TEXT, memory TEXT, nic TEXT, storage TEXT, cloud_instance TEXT, other_software TEXT, extra TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
@@ -150,7 +150,7 @@ namespace eval jobs {
             } elseif [ catch {hdbjobs eval {CREATE TABLE JOBTCOUNT(jobid TEXT, counter INTEGER, metric TEXT, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
               puts "Error creating JOBTCOUNT table in SQLite on-disk database : $message"
               return
-            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
+            } elseif [ catch {hdbjobs eval {CREATE TABLE JOBMETRIC (jobid TEXT, usr REAL, sys REAL, irq REAL, idle REAL, iops REAL, mbps REAL, timestamp DATETIME NOT NULL DEFAULT (datetime(CURRENT_TIMESTAMP, 'localtime')), FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
              puts "Error creating JOBMETRIC table in SQLite on-disk database : $message"
              return
 	          } elseif [ catch {hdbjobs eval {CREATE TABLE JOBSYSTEM (jobid TEXT primary key, hostname TEXT, cpumodel TEXT, cpucount INTEGER, system_vendor TEXT, system_type TEXT, os_name TEXT, memory TEXT, nic TEXT, storage TEXT, cloud_instance TEXT, other_software TEXT, extra TEXT, FOREIGN KEY(jobid) REFERENCES JOBMAIN(jobid))}} message ] {
@@ -210,6 +210,18 @@ namespace eval jobs {
                }
            } message] } {
                puts "Error upgrading JOBSYSTEM table with system discovery fields: $message"
+           }
+           if { [catch {
+               set metriccol_iops [hdbjobs eval {SELECT COUNT(*) FROM pragma_table_info('JOBMETRIC') WHERE name='iops'}]
+               if { $metriccol_iops eq 0 } {
+                   hdbjobs eval {ALTER TABLE JOBMETRIC ADD COLUMN iops REAL}
+               }
+               set metriccol_mbps [hdbjobs eval {SELECT COUNT(*) FROM pragma_table_info('JOBMETRIC') WHERE name='mbps'}]
+               if { $metriccol_mbps eq 0 } {
+                   hdbjobs eval {ALTER TABLE JOBMETRIC ADD COLUMN mbps REAL}
+               }
+           } message] } {
+               puts "Error upgrading JOBMETRIC table with I/O fields: $message"
            }
 	   }}}}
       tsv::set commandline sqldb $sqlite_db
@@ -2452,8 +2464,8 @@ if {$rawmode} {
 
   proc getjobmetrics { jobid } {
     set jobmetric [ dict create ]
-    hdbjobs eval {select JOBMETRIC.timestamp, usr, sys, irq, idle from JOBMETRIC WHERE JOBMETRIC.JOBID=$jobid order by JOBMETRIC.timestamp asc} {
-    set metrics "usr% $usr sys% $sys irq% $irq idle% $idle" 
+    hdbjobs eval {select JOBMETRIC.timestamp, usr, sys, irq, idle, coalesce(iops,0) as iops, coalesce(mbps,0) as mbps from JOBMETRIC WHERE JOBMETRIC.JOBID=$jobid order by JOBMETRIC.timestamp asc} {
+    set metrics "usr% $usr sys% $sys irq% $irq idle% $idle iops $iops mbps $mbps" 
 	if { [dict keys $jobmetric $timestamp] eq {} } {
     	dict append jobmetric $timestamp $metrics
 		}
@@ -2861,24 +2873,31 @@ if {$rawmode} {
 	  return
 	}
 	  set axisname "CPU %"
+          set ioaxisname "I/O"
           set xaxisvals [ dict keys $chartdata ]
           dict for {tstamp cpuvalues} $chartdata {
           dict with cpuvalues {
             lappend usrseries ${usr%}
             lappend sysseries ${sys%}
             lappend irqseries ${irq%}
+            lappend iopsseries $iops
+            lappend mbpsseries $mbps
           }}
           #Delete the first and trailing values if usr utilisation is 0, so we start from the first measurement and only chart when running
           if { [ lindex $usrseries 0 ] eq 0.0 } {
             set usrseries [ lreplace $usrseries 0 0 ]
             set sysseries [ lreplace $sysseries 0 0 ]
             set irqseries [ lreplace $irqseries 0 0 ]
+            set iopsseries [ lreplace $iopsseries 0 0 ]
+            set mbpsseries [ lreplace $mbpsseries 0 0 ]
             set xaxisvals [ lreplace $xaxisvals 0 0 ]
           }
           while { [ lindex $usrseries end ] eq 0.0 } {
             set usrseries [ lreplace $usrseries end end ]
             set sysseries [ lreplace $sysseries end end ]
             set irqseries [ lreplace $irqseries end end ]
+            set iopsseries [ lreplace $iopsseries end end ]
+            set mbpsseries [ lreplace $mbpsseries end end ]
             set xaxisvals [ lreplace $xaxisvals end end ]
           }
 	  if { ![ info exists dbdescription ] } { set dbdescription "Generic CPU" }
@@ -2894,10 +2913,13 @@ if {$rawmode} {
                            -legend [list bottom "5%" left "40%" selected $irqJS]
           $line Xaxis -data [list $xaxisvals] -axisLabel [list show "True"]
           $line Yaxis -name "$axisname" -position "left" -axisLabel {formatter {"{value}"}}
+          $line Yaxis -name "$ioaxisname" -position "right" -axisLabel {formatter {"{value}"}}
           $line Add "lineSeries" -name "usr%" -data [ list $usrseries ] -itemStyle [ subst {color green opacity 0.90} ]
           $line Add "lineSeries" -name "sys%" -data [ list $sysseries ] -itemStyle [ subst {color red opacity 0.90} ]
 	        # 'irqseries' is included but hidden by default with 'showIrqSeries' variable set.
           $line Add "lineSeries" -name $irqSeriesName -data [ list $irqseries ] -itemStyle [ subst {color blue opacity 0.90} ]
+          $line Add "lineSeries" -name "IOPS" -yAxisIndex 1 -data [ list $iopsseries ] -itemStyle [ subst {color orange opacity 0.90} ]
+          $line Add "lineSeries" -name "MB/s" -yAxisIndex 1 -data [ list $mbpsseries ] -itemStyle [ subst {color purple opacity 0.90} ]
           set html [ $line toHTML -title "$jobid " ]
           #If we query the metrics chart while the job is running it will not be generated again
           #meaning the output will be truncated

--- a/src/generic/genmetrics.tcl
+++ b/src/generic/genmetrics.tcl
@@ -191,12 +191,32 @@ foreach x { usrlist syslist irqlist idlelist } y { usr sys irq idle } {
 	}
 }
 
+proc addiostats { iops mbps } {
+    global iopslist mbpslist
+    foreach x { iopslist mbpslist } y { iops mbps } {
+        lappend $x [set $y]
+        if {[llength [set $x]] > 5} {
+            set $x [lrange [set $x] end-4 end]
+        }
+    }
+}
+
 proc StatsOneLine {line} {
-global jobid usrlist syslist irqlist idlelist agent_hostname
+global jobid usrlist syslist irqlist idlelist iopslist mbpslist agent_hostname
 proc gmean L {
     expr pow([join $L *],1./[llength $L])
 }
+    proc amean L {
+        expr {[join $L +] / double([llength $L])}
+    }
     #Called by agent remotely
+    if { [llength $line] eq 3 && [lindex $line 0] eq "IOSTAT" } {
+        lassign $line tag iops mbps
+        if {[string is double -strict $iops] && [string is double -strict $mbps]} {
+            addiostats $iops $mbps
+        }
+        return
+    }
     #Different formats some include AMPM some don't
     if { [ llength $line ] eq 12 } {
         lassign $line when ampm cpu usr nice sys iowait irq soft steal guest idle
@@ -216,9 +236,17 @@ proc gmean L {
 	foreach x { usrlist syslist irqlist idlelist } y { usrgmean sysgmean irqgmean idlegmean } {
 	set $y [format "%3.2f" [ gmean [ set $x ]]]
 	}
+        set iopsmean 0.00
+        set mbpsmean 0.00
+        if {[info exists iopslist] && [llength $iopslist] > 0} {
+            set iopsmean [format "%3.2f" [amean $iopslist]]
+        }
+        if {[info exists mbpslist] && [llength $mbpslist] > 0} {
+            set mbpsmean [format "%3.2f" [amean $mbpslist]]
+        }
     	if { [ interp exists metrics_interp ] } {
 	 if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
-        hdbjobs eval {INSERT INTO JOBMETRIC(jobid,usr,sys,irq,idle) VALUES($jobid,$usrgmean,$sysgmean,$irqgmean,$idlegmean)}
+        hdbjobs eval {INSERT INTO JOBMETRIC(jobid,usr,sys,irq,idle,iops,mbps) VALUES($jobid,$usrgmean,$sysgmean,$irqgmean,$idlegmean,$iopsmean,$mbpsmean)}
 	#Metrics started before job was running, if placeholder in jobsystem update with correct jobid
         set jobhost [ hdbjobs eval {select hostname from JOBSYSTEM where JOBID=$jobid} ]
 	if {$jobhost eq ""} {

--- a/src/generic/genmetricscli.tcl
+++ b/src/generic/genmetricscli.tcl
@@ -290,12 +290,32 @@ foreach x { usrlist syslist irqlist idlelist } y { usr sys irq idle } {
 	}
 }
 
+proc addiostats { iops mbps } {
+    global iopslist mbpslist
+    foreach x { iopslist mbpslist } y { iops mbps } {
+        lappend $x [set $y]
+        if {[llength [set $x]] > 5} {
+            set $x [lrange [set $x] end-4 end]
+        }
+    }
+}
+
 proc StatsOneLine {line} {
-global jobid usrlist syslist irqlist idlelist agent_hostname
+global jobid usrlist syslist irqlist idlelist iopslist mbpslist agent_hostname
 proc gmean L {
     expr pow([join $L *],1./[llength $L])
 }
+    proc amean L {
+        expr {[join $L +] / double([llength $L])}
+    }
     #Called by agent remotely
+    if { [llength $line] eq 3 && [lindex $line 0] eq "IOSTAT" } {
+        lassign $line tag iops mbps
+        if {[string is double -strict $iops] && [string is double -strict $mbps]} {
+            addiostats $iops $mbps
+        }
+        return
+    }
     #Different formats some include AMPM some don't
     if { [ llength $line ] eq 12 } {
         lassign $line when ampm cpu usr nice sys iowait irq soft steal guest idle
@@ -315,13 +335,21 @@ proc gmean L {
 	foreach x { usrlist syslist irqlist idlelist } y { usrgmean sysgmean irqgmean idlegmean } {
 	set $y [format "%3.2f" [ gmean [ set $x ]]]
 	}
+    set iopsmean 0.00
+    set mbpsmean 0.00
+    if {[info exists iopslist] && [llength $iopslist] > 0} {
+        set iopsmean [format "%3.2f" [amean $iopslist]]
+    }
+    if {[info exists mbpslist] && [llength $mbpslist] > 0} {
+        set mbpsmean [format "%3.2f" [amean $mbpslist]]
+    }
     	if { [ interp exists metrics_interp ] } {
-	putscli "CPU all usr%-$usrgmean sys%-$sysgmean irq%-$irqgmean idle%-$idlegmean"
+	putscli "CPU all usr%-$usrgmean sys%-$sysgmean irq%-$irqgmean idle%-$idlegmean IOPS-$iopsmean MB/s-$mbpsmean"
 	 if { [ info exists jobid] && $jobid != "" && $jobid != 0 } {
          if { [ string match Benchmark* $jobid ] } {
          set jobid [ regsub {Benchmark.*=} $jobid ""]
 	 }
-        hdbjobs eval {INSERT INTO JOBMETRIC(jobid,usr,sys,irq,idle) VALUES($jobid,$usrgmean,$sysgmean,$irqgmean,$idlegmean)}
+        hdbjobs eval {INSERT INTO JOBMETRIC(jobid,usr,sys,irq,idle,iops,mbps) VALUES($jobid,$usrgmean,$sysgmean,$irqgmean,$idlegmean,$iopsmean,$mbpsmean)}
         #Metrics started before job was running, if placeholder in jobsystem update with correct jobid
         set jobhost [ hdbjobs eval {select hostname from JOBSYSTEM where JOBID=$jobid} ]
         if {$jobhost eq ""} {


### PR DESCRIPTION
### Motivation

- Provide I/O telemetry (IOPS and MB/s) alongside existing CPU metrics so jobs and charts show storage activity and correlate I/O with CPU usage.
- Allow existing installations to persist and query I/O metrics alongside CPU metrics for better performance analysis.

### Description

- Agent: added periodic I/O collection and publishing; new functions `RunIOMetrics`, `CollectIOMetricsLinux`, `CollectIOMetricsWindows` and `SendIOLine` emit `IOSTAT` samples (IOPS and MB/s) to connected displays. Linux reads `/proc/diskstats` and computes deltas; Windows uses TWAPI PDH counters when available.
- Metrics ingest/display: updated `StatsOneLine` handlers in `src/generic/genmetrics.tcl` and `src/generic/genmetricscli.tcl` to accept `IOSTAT` messages, maintain rolling I/O lists via `addiostats`, include averaged I/O in the CLI summary line, and persist I/O with CPU metrics.
- Schema and Jobs reporting: expanded `JOBMETRIC` schema to include `iops` and `mbps` and added an on-upgrade path using `PRAGMA table_info` + `ALTER TABLE` to add missing columns for existing DBs; `getjobmetrics` now returns I/O values; the Jobs metrics chart generation adds `IOPS` and `MB/s` series on a secondary Y axis for visualisation.
- Defensive behavior: I/O collection degrades safely if counters/files are unavailable (returns zeros or skips until data is available) and transient send errors are ignored to allow normal reconnect logic.

### Testing

- Ran structural Tcl file completeness checks using an `info complete` script across modified files (`agent/agent`, `src/generic/genmetrics.tcl`, `src/generic/genmetricscli.tcl`, `modules/jobs-1.0.tm`) and all returned OK.
- Verified basic runtime paths by exercising the metrics startup path so `RunIOMetrics` is scheduled; I/O collectors return empty on first sample and subsequent deltas are computed (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec778882dc832488f298153127febe)