### PR TITLE
Align TPC-C stored procs across backends: stock/accounting updates and simplify line amount calc

### DIFF
--- a/src/db2/db2oltp.tcl
+++ b/src/db2/db2oltp.tcl
@@ -109,13 +109,16 @@ proc CreateStoredProcs { db_handle } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM NEW TABLE (UPDATE STOCK
-        SET s_quantity = CASE WHEN ( s_quantity > no_ol_quantity )
+        SET s_quantity = CASE WHEN ( s_quantity >= ( no_ol_quantity + 10 ) )
         THEN ( s_quantity - no_ol_quantity )
         ELSE ( s_quantity - no_ol_quantity + 91 )
-        END
+        END,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + CASE WHEN ( no_ol_supply_w_id <> no_w_id ) THEN 1 ELSE 0 END
         WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id
         ) AS US;
-        SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+        SET no_ol_amount = (  no_ol_quantity * no_i_price );
         CASE no_d_id
         WHEN 1 THEN
         SET no_ol_dist_info = no_s_dist_01;
@@ -242,11 +245,11 @@ proc CreateStoredProcs { db_handle } {
         SET p_c_new_data = (TO_CHAR(p_c_id) || ' ' || TO_CHAR(p_c_d_id) || ' ' || TO_CHAR(p_c_w_id) || ' ' || TO_CHAR(p_d_id) || ' ' || TO_CHAR(p_w_id) || ' ' || VARCHAR_FORMAT(p_h_amount,'9999.99') || VARCHAR_FORMAT(timestamp,'YYYYMMDDHH24MISS') || h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -284,7 +287,7 @@ proc CreateStoredProcs { db_handle } {
         SET ol_delivery_d = tstamp
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id AND
         ol_w_id = d_w_id);
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         set deliv_data[loop_counter] = d_no_o_id;

--- a/src/mariadb/mariaoltp.tcl
+++ b/src/mariadb/mariaoltp.tcl
@@ -124,16 +124,19 @@ proc CreateStoredProcs { maria_handler } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-        IF ( no_s_quantity > no_ol_quantity )
+        IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
         THEN
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity );
         ELSE
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity + 91 );
         END IF;
-        UPDATE stock SET s_quantity = no_s_quantity
+        UPDATE stock SET s_quantity = no_s_quantity,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + IF(no_ol_supply_w_id != no_w_id,1,0)
         WHERE s_i_id = no_ol_i_id
         AND s_w_id = no_ol_supply_w_id;
-        SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+        SET no_ol_amount = (  no_ol_quantity * no_i_price );
         CASE no_d_id
         WHEN 1 THEN
         SET no_ol_dist_info = no_s_dist_01;
@@ -200,7 +203,7 @@ proc CreateStoredProcs { maria_handler } {
         FROM order_line
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
         AND ol_w_id = d_w_id;
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         SET deliv_data = CONCAT(d_d_id,' ',d_no_o_id,' ',timestamp);
@@ -314,11 +317,11 @@ proc CreateStoredProcs { maria_handler } {
         SET p_c_new_data = CONCAT(CAST(p_c_id AS CHAR),' ',CAST(p_c_d_id AS CHAR),' ',CAST(p_c_w_id AS CHAR),' ',CAST(p_d_id AS CHAR),' ',CAST(p_w_id AS CHAR),' ',CAST(FORMAT(p_h_amount,2) AS CHAR),CAST(timestamp AS CHAR),h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -1480,13 +1483,13 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
       set quantity_data_dist [ maria::sel $maria_handler "SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id" -flatlist ]
       set no_i_price [ lindex $price_name_data 0 ]
       set no_s_quantity [ lindex $quantity_data_dist 0 ]
-      if { $no_s_quantity > $no_ol_quantity } {
+      if { $no_s_quantity >= ($no_ol_quantity + 10) } {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity} ]
       } else {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity + 91} ]
       }
-      mariaexec $maria_handler "UPDATE stock SET s_quantity = $no_s_quantity WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
-      set no_ol_amount [ expr {($no_ol_quantity * $no_i_price * ( 1 + $no_w_tax + $no_d_tax ) * ( 1 - $no_c_discount ))} ]
+      mariaexec $maria_handler "UPDATE stock SET s_quantity = $no_s_quantity, s_ytd = s_ytd + $no_ol_quantity, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + IF($no_ol_supply_w_id != $no_w_id,1,0) WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
+      set no_ol_amount [ expr {($no_ol_quantity * $no_i_price)} ]
       switch $no_d_id {
         1 { set no_ol_dist_info [ lindex $quantity_data_dist 2 ] }
         2 { set no_ol_dist_info [ lindex $quantity_data_dist 3 ] }
@@ -1571,9 +1574,9 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
       set h_data [ concat $p_w_name $p_d_name ]
       set p_c_new_data [ concat p_c_id $p_c_id p_c_d_id $p_c_d_id p_c_w_id $p_c_w_id p_d_id $p_d_id p_w_id $p_w_id p_h_amount [ format %4.2f $p_h_amount ] h_date $h_date h_data $h_data ]
       set p_c_new_data [ string range [ concat $p_c_new_data $c_data ] 1 [ expr 500 - [ string length $p_c_new_data ] ] ]
-      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data' WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data', c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
     } else {
-      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mariaexec $maria_handler "UPDATE customer SET c_balance = $p_c_balance, c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
       set c_data ""
     }
     set h_data [ concat $p_w_name $p_d_name ]
@@ -1639,7 +1642,7 @@ proc insert_maria_no_stored_procs { testtype timedtype } {
 	mariaexec $maria_handler "UPDATE orders SET o_carrier_id = $carrier_id WHERE o_id = $no_o_id AND o_d_id = $d_d_id AND o_w_id = $w_id"
 	mariaexec $maria_handler "UPDATE order_line SET ol_delivery_d = str_to_date($date,'%Y%m%d%H%i%s') WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id"
    	set d_ol_total [ list [ maria::sel $maria_handler "SELECT SUM(ol_amount) FROM order_line WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id" -list ]]
-	mariaexec $maria_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
+	mariaexec $maria_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
 	incr loop_counter
        	}
 	maria::commit $maria_handler

--- a/src/mssqlserver/mssqlsoltp.tcl
+++ b/src/mssqlserver/mssqlsoltp.tcl
@@ -135,8 +135,11 @@ proc CreateStoredProcs { odbc imdb } {
             WHERE item.i_id = @no_ol_i_id
             UPDATE dbo.stock
             SET
-            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity > @no_ol_quantity)
+            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity >= (@no_ol_quantity + 10))
             THEN 0 ELSE 91 END,
+            s_ytd = s_ytd + @no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN (@no_ol_supply_w_id <> @no_w_id) THEN 1 ELSE 0 END,
             @no_s_data = s_data,
             @no_ol_dist_info =
             CASE @no_d_id
@@ -256,7 +259,7 @@ proc CreateStoredProcs { odbc imdb } {
             AND order_line.ol_d_id = @d_d_id
             AND order_line.ol_w_id = @d_w_id
             END
-            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total
+            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE customer.c_id = @d_c_id
             AND customer.c_d_id = @d_d_id
             AND customer.c_w_id = @d_w_id
@@ -358,6 +361,8 @@ proc CreateStoredProcs { odbc imdb } {
             UPDATE dbo.customer
             SET
             @p_c_balance = c_balance = c_balance - @p_h_amount,
+            c_ytd_payment = c_ytd_payment + @p_h_amount,
+            c_payment_cnt = c_payment_cnt + 1,
             c_data =
             CASE
             WHEN c_credit <> 'BC' THEN c_credit
@@ -683,8 +688,11 @@ proc CreateStoredProcs { odbc imdb } {
             WHERE item.i_id = @no_ol_i_id
             UPDATE dbo.stock
             SET
-            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity > @no_ol_quantity)
+            s_quantity = s_quantity - @no_ol_quantity + CASE WHEN (s_quantity >= (@no_ol_quantity + 10))
             THEN 0 ELSE 91 END,
+            s_ytd = s_ytd + @no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN (@no_ol_supply_w_id <> @no_w_id) THEN 1 ELSE 0 END,
             @no_s_data = s_data,
             @no_ol_dist_info =
             CASE @no_d_id
@@ -801,7 +809,7 @@ proc CreateStoredProcs { odbc imdb } {
             AND order_line.ol_d_id = @d_d_id
             AND order_line.ol_w_id = @d_w_id
             END
-            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total
+            UPDATE dbo.customer SET c_balance = customer.c_balance + @d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE customer.c_id = @d_c_id
             AND customer.c_d_id = @d_d_id
             AND customer.c_w_id = @d_w_id
@@ -900,6 +908,8 @@ proc CreateStoredProcs { odbc imdb } {
             UPDATE dbo.customer
             SET
             @p_c_balance = c_balance = c_balance - @p_h_amount,
+            c_ytd_payment = c_ytd_payment + @p_h_amount,
+            c_payment_cnt = c_payment_cnt + 1,
             c_data =
             CASE
             WHEN c_credit <> 'BC' THEN c_credit

--- a/src/mysql/mysqloltp.tcl
+++ b/src/mysql/mysqloltp.tcl
@@ -117,16 +117,19 @@ proc CreateStoredProcs { mysql_handler } {
         SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
         INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10
         FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-        IF ( no_s_quantity > no_ol_quantity )
+        IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
         THEN
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity );
         ELSE
         SET no_s_quantity = ( no_s_quantity - no_ol_quantity + 91 );
         END IF;
-        UPDATE stock SET s_quantity = no_s_quantity
+        UPDATE stock SET s_quantity = no_s_quantity,
+        s_ytd = s_ytd + no_ol_quantity,
+        s_order_cnt = s_order_cnt + 1,
+        s_remote_cnt = s_remote_cnt + IF(no_ol_supply_w_id != no_w_id,1,0)
         WHERE s_i_id = no_ol_i_id
         AND s_w_id = no_ol_supply_w_id;
-        SET no_ol_amount = (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+        SET no_ol_amount = (  no_ol_quantity * no_i_price );
         CASE no_d_id
         WHEN 1 THEN
         SET no_ol_dist_info = no_s_dist_01;
@@ -191,7 +194,7 @@ proc CreateStoredProcs { mysql_handler } {
         FROM order_line
         WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
         AND ol_w_id = d_w_id;
-        UPDATE customer SET c_balance = c_balance + d_ol_total
+        UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
         WHERE c_id = d_c_id AND c_d_id = d_d_id AND
         c_w_id = d_w_id;
         SET deliv_data = CONCAT(d_d_id,' ',d_no_o_id,' ',timestamp);
@@ -303,11 +306,11 @@ proc CreateStoredProcs { mysql_handler } {
         SET p_c_new_data = CONCAT(CAST(p_c_id AS CHAR),' ',CAST(p_c_d_id AS CHAR),' ',CAST(p_c_w_id AS CHAR),' ',CAST(p_d_id AS CHAR),' ',CAST(p_w_id AS CHAR),' ',CAST(FORMAT(p_h_amount,2) AS CHAR),CAST(timestamp AS CHAR),h_data);
         SET p_c_new_data = SUBSTR(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
         UPDATE customer
-        SET c_balance = p_c_balance, c_data = p_c_new_data
+        SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         ELSE
-        UPDATE customer SET c_balance = p_c_balance
+        UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
         WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
         c_id = p_c_id;
         END IF;
@@ -1458,13 +1461,13 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
       set quantity_data_dist [ mysql::sel $mysql_handler "SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10 FROM stock WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id" -flatlist ]
       set no_i_price [ lindex $price_name_data 0 ]
       set no_s_quantity [ lindex $quantity_data_dist 0 ]
-      if { $no_s_quantity > $no_ol_quantity } {
+      if { $no_s_quantity >= ($no_ol_quantity + 10) } {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity} ]
       } else {
         set no_s_quantity [ expr {$no_s_quantity - $no_ol_quantity + 91} ]
       }
-      mysqlexec $mysql_handler "UPDATE stock SET s_quantity = $no_s_quantity WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
-      set no_ol_amount [ expr {($no_ol_quantity * $no_i_price * ( 1 + $no_w_tax + $no_d_tax ) * ( 1 - $no_c_discount ))} ]
+      mysqlexec $mysql_handler "UPDATE stock SET s_quantity = $no_s_quantity, s_ytd = s_ytd + $no_ol_quantity, s_order_cnt = s_order_cnt + 1, s_remote_cnt = s_remote_cnt + IF($no_ol_supply_w_id != $no_w_id,1,0) WHERE s_i_id = $no_ol_i_id AND s_w_id = $no_ol_supply_w_id"
+      set no_ol_amount [ expr {($no_ol_quantity * $no_i_price)} ]
       switch $no_d_id {
         1 { set no_ol_dist_info [ lindex $quantity_data_dist 2 ] }
         2 { set no_ol_dist_info [ lindex $quantity_data_dist 3 ] }
@@ -1549,9 +1552,9 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
       set h_data [ concat $p_w_name $p_d_name ]
       set p_c_new_data [ concat p_c_id $p_c_id p_c_d_id $p_c_d_id p_c_w_id $p_c_w_id p_d_id $p_d_id p_w_id $p_w_id p_h_amount [ format %4.2f $p_h_amount ] h_date $h_date h_data $h_data ]
       set p_c_new_data [ string range [ concat $p_c_new_data $c_data ] 1 [ expr 500 - [ string length $p_c_new_data ] ] ]
-      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data' WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_data = '$p_c_new_data', c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
     } else {
-      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
+      mysqlexec $mysql_handler "UPDATE customer SET c_balance = $p_c_balance, c_ytd_payment = c_ytd_payment + $p_h_amount, c_payment_cnt = c_payment_cnt + 1 WHERE c_w_id = $p_c_w_id AND c_d_id = $p_c_d_id AND c_id = $p_c_id"
       set c_data ""
     }
     set h_data [ concat $p_w_name $p_d_name ]
@@ -1617,7 +1620,7 @@ proc insert_mysql_no_stored_procs { testtype timedtype } {
 	mysqlexec $mysql_handler "UPDATE orders SET o_carrier_id = $carrier_id WHERE o_id = $no_o_id AND o_d_id = $d_d_id AND o_w_id = $w_id"
 	mysqlexec $mysql_handler "UPDATE order_line SET ol_delivery_d = str_to_date($date,'%Y%m%d%H%i%s') WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id"
    	set d_ol_total [ list [ mysql::sel $mysql_handler "SELECT SUM(ol_amount) FROM order_line WHERE ol_o_id = $no_o_id AND ol_d_id = $d_d_id AND ol_w_id = $w_id" -list ]]
-	mysqlexec $mysql_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
+	mysqlexec $mysql_handler "UPDATE customer SET c_balance = c_balance + $d_ol_total, c_delivery_cnt = c_delivery_cnt + 1 WHERE c_id = $o_c_id AND c_d_id = $d_d_id AND c_w_id = $w_id"
 	incr loop_counter
        	}
 	mysql::commit $mysql_handler

--- a/src/oracle/oraoltp.tcl
+++ b/src/oracle/oraoltp.tcl
@@ -127,17 +127,20 @@ proc CreateStoredProcs { lda timesten num_part } {
             FROM item WHERE i_id = no_ol_i_id;
             SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
             INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-            IF ( no_s_quantity > no_ol_quantity )
+            IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
             THEN
             no_s_quantity := ( no_s_quantity - no_ol_quantity );
             ELSE
             no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
             END IF;
-            UPDATE stock SET s_quantity = no_s_quantity
+            UPDATE stock SET s_quantity = no_s_quantity,
+            s_ytd = s_ytd + no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN no_ol_supply_w_id != no_w_id THEN 1 ELSE 0 END
             WHERE s_i_id = no_ol_i_id
             AND s_w_id = no_ol_supply_w_id;
 
-            no_ol_amount := (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+            no_ol_amount := (  no_ol_quantity * no_i_price );
 
             IF no_d_id = 1
             THEN 
@@ -423,7 +426,7 @@ proc CreateStoredProcs { lda timesten num_part } {
                 FROM order_line
                 WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
                 AND ol_w_id = d_w_id;
-                UPDATE customer SET c_balance = c_balance + d_ol_total
+                UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
                 WHERE c_id = d_c_id AND c_d_id = d_d_id AND
                 c_w_id = d_w_id;
                 COMMIT;
@@ -471,7 +474,7 @@ proc CreateStoredProcs { lda timesten num_part } {
                 FROM order_line
                 WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
                 AND ol_w_id = d_w_id;
-                UPDATE customer SET c_balance = c_balance + d_ol_total
+                UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
                 WHERE c_id = d_c_id AND c_d_id = d_d_id AND
                 c_w_id = d_w_id;
                 COMMIT;
@@ -540,9 +543,8 @@ proc CreateStoredProcs { lda timesten num_part } {
 
             FORALL c IN 1.. ordcnt
             UPDATE customer
-            SET c_balance = c_balance + sums(c)
-            -- Added this in for the refactor but it's not in the original (although it should be) so I've removed it, to be true to the original
-            --, c_delivery_cnt = c_delivery_cnt + 1
+            SET c_balance = c_balance + sums(c),
+            c_delivery_cnt = c_delivery_cnt + 1
             WHERE c_w_id = d_w_id
             AND c_d_id = dist_id_array(c)
             AND c_id = order_c_id(c);
@@ -624,9 +626,9 @@ proc CreateStoredProcs { lda timesten num_part } {
         cust_rowid := row_id ((c_num + 1) / 2);
 
         UPDATE customer
-        SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
+        SET c_balance = c_balance - p_h_amount,
+        c_ytd_payment = c_ytd_payment + p_h_amount,
+        c_payment_cnt = c_payment_cnt + 1
         WHERE rowid = cust_rowid
         RETURNING c_id, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,
@@ -638,9 +640,9 @@ proc CreateStoredProcs { lda timesten num_part } {
         p_c_discount, p_c_balance;
         ELSE
         UPDATE customer
-        SET c_balance = c_balance - p_h_amount
-        --c_ytd_payment = c_ytd_payment + hist_amount,
-        --c_payment_cnt = c_payment_cnt + 1
+        SET c_balance = c_balance - p_h_amount,
+        c_ytd_payment = c_ytd_payment + p_h_amount,
+        c_payment_cnt = c_payment_cnt + 1
         WHERE c_id = p_c_id AND c_d_id = p_c_d_id AND c_w_id = p_c_w_id
         RETURNING rowid, c_first, c_middle, c_last, c_street_1, c_street_2,
         c_city, c_state, c_zip, c_phone,

--- a/src/postgresql/pgoltp.tcl
+++ b/src/postgresql/pgoltp.tcl
@@ -125,17 +125,20 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             FROM item WHERE i_id = no_ol_i_id;
             SELECT s_quantity, s_data, s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10
             INTO no_s_quantity, no_s_data, no_s_dist_01, no_s_dist_02, no_s_dist_03, no_s_dist_04, no_s_dist_05, no_s_dist_06, no_s_dist_07, no_s_dist_08, no_s_dist_09, no_s_dist_10 FROM stock WHERE s_i_id = no_ol_i_id AND s_w_id = no_ol_supply_w_id;
-            IF ( no_s_quantity > no_ol_quantity )
+            IF ( no_s_quantity >= ( no_ol_quantity + 10 ) )
             THEN
             no_s_quantity := ( no_s_quantity - no_ol_quantity );
             ELSE
             no_s_quantity := ( no_s_quantity - no_ol_quantity + 91 );
             END IF;
-            UPDATE stock SET s_quantity = no_s_quantity
+            UPDATE stock SET s_quantity = no_s_quantity,
+            s_ytd = s_ytd + no_ol_quantity,
+            s_order_cnt = s_order_cnt + 1,
+            s_remote_cnt = s_remote_cnt + CASE WHEN no_ol_supply_w_id != no_w_id THEN 1 ELSE 0 END
             WHERE s_i_id = no_ol_i_id
             AND s_w_id = no_ol_supply_w_id;
 
-            no_ol_amount := (  no_ol_quantity * no_i_price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) );
+            no_ol_amount := (  no_ol_quantity * no_i_price );
 
             IF no_d_id = 1
             THEN 
@@ -217,7 +220,7 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             FROM order_line
             WHERE ol_o_id = d_no_o_id AND ol_d_id = d_d_id
             AND ol_w_id = d_w_id;
-            UPDATE customer SET c_balance = c_balance + d_ol_total
+            UPDATE customer SET c_balance = c_balance + d_ol_total, c_delivery_cnt = c_delivery_cnt + 1
             WHERE c_id = d_c_id AND c_d_id = d_d_id AND
             c_w_id = d_w_id;
             DBMS_OUTPUT.PUT_LINE('D: ' || d_d_id || 'O: ' || d_no_o_id || 'time ' || tstamp);
@@ -330,11 +333,11 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
             TO_CHAR(p_c_w_id) || ' ' || TO_CHAR(p_d_id) || ' ' || TO_CHAR(p_w_id) || ' ' || TO_CHAR(p_h_amount,'9999.99') || TO_CHAR(tstamp) || h_data);
             p_c_new_data := substr(CONCAT(p_c_new_data,p_c_data),1,500-(LENGTH(p_c_new_data)));
             UPDATE customer
-            SET c_balance = p_c_balance, c_data = p_c_new_data
+            SET c_balance = p_c_balance, c_data = p_c_new_data, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
             WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
             c_id = p_c_id;
             ELSE
-            UPDATE customer SET c_balance = p_c_balance
+            UPDATE customer SET c_balance = p_c_balance, c_ytd_payment = c_ytd_payment + p_h_amount, c_payment_cnt = c_payment_cnt + 1
             WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND
             c_id = p_c_id;
             END IF;
@@ -548,13 +551,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -563,13 +569,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -578,13 +587,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -593,13 +605,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -608,13 +623,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -623,13 +641,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -638,13 +659,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -653,13 +677,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -668,13 +695,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -683,13 +713,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -887,6 +920,8 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 UPDATE customer
                 SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1,
                 c_data = substr ((p_c_id || ' ' ||
                 p_c_d_id || ' ' ||
                 p_c_w_id || ' ' ||
@@ -899,7 +934,9 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
                 ELSE
                 UPDATE customer
-                SET c_balance = p_c_balance - p_h_amount
+                SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1
                 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_data;
                 END IF;
@@ -1085,13 +1122,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_01 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1100,13 +1140,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_02 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1115,13 +1158,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_03 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1130,13 +1176,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_04 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1145,13 +1194,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_05 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1160,13 +1212,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_06 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1175,13 +1230,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_07 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1190,13 +1248,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_08 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1205,13 +1266,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_09 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1220,13 +1284,16 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 WITH stock_update AS (
                 UPDATE stock
-                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity
+                SET s_quantity = ( CASE WHEN s_quantity < (item_stock.quantity + 10) THEN s_quantity + 91 ELSE s_quantity END) - item_stock.quantity,
+                s_ytd = s_ytd + item_stock.quantity,
+                s_order_cnt = s_order_cnt + 1,
+                s_remote_cnt = s_remote_cnt + CASE WHEN (item_stock.supply_wid <> no_w_id) THEN 1 ELSE 0 END
                 FROM UNNEST(item_id_array, supply_wid_array, quantity_array, price_array)
                 AS item_stock (item_id, supply_wid, quantity, price)
                 WHERE stock.s_i_id = item_stock.item_id
                 AND stock.s_w_id = item_stock.supply_wid
                 AND stock.s_w_id = ANY(supply_wid_array)
-                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity + item_stock.price * ( 1 + no_w_tax + no_d_tax ) * ( 1 - no_c_discount ) ) amount
+                RETURNING stock.s_dist_10 as s_dist, stock.s_quantity, ( item_stock.quantity * item_stock.price ) amount
                 )
                 SELECT array_agg ( s_dist ), array_agg ( s_quantity ), array_agg ( amount )
                 FROM stock_update
@@ -1434,6 +1501,8 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 THEN
                 UPDATE customer
                 SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1,
                 c_data = substr ((p_c_id || '' '' ||
                 p_c_d_id || '' '' ||
                 p_c_w_id || '' '' ||
@@ -1444,7 +1513,9 @@ proc CreateStoredProcs { lda ora_compatible citus_compatible pg_storedprocs } {
                 RETURNING c_balance, c_data INTO p_c_balance, p_c_new_data;
                 ELSE
                 UPDATE customer
-                SET c_balance = p_c_balance - p_h_amount
+                SET c_balance = p_c_balance - p_h_amount,
+                c_ytd_payment = c_ytd_payment + p_h_amount,
+                c_payment_cnt = c_payment_cnt + 1
                 WHERE c_w_id = p_c_w_id AND c_d_id = p_c_d_id AND c_id = p_c_id
                 RETURNING c_balance, '' '' INTO p_c_balance, p_c_new_data;
                 END IF;


### PR DESCRIPTION
### Motivation
- Align stored procedures and client-side logic with expected TPC-C semantics by updating stock accounting, customer payment/delivery counters, and order-line amount computation across all supported backends.
- Ensure consistent behavior between stored and non-stored implementations used by the workload generator.

### Description
- Change stock decrement threshold checks to use `>= (no_ol_quantity + 10)` and update `s_ytd`, `s_order_cnt`, and `s_remote_cnt` when stock is adjusted, applied in SQL/stored-proc and TCL code paths. 
- Simplify order-line amount calculation to `no_ol_amount = no_ol_quantity * no_i_price` (removing the previous tax/discount factors) in all backends and client-side code. 
- Increment customer accounting counters: add `c_ytd_payment` and `c_payment_cnt` updates in `PAYMENT` flows and add `c_delivery_cnt` increments in `DELIVERY` flows across DB2, MariaDB, MySQL, MSSQL, Oracle, PostgreSQL and related TCL helper scripts. 
- Apply the above changes consistently to both stored-procedure DDL bodies and the non-stored TCL implementations that generate/execute the same logic.

### Testing
- Ran the repository's stored-proc generation and TCL syntax checks for the modified files and confirmed no syntax errors were produced. 
- Executed the TPC-C smoke/integration run (stored and non-stored paths) against local test instances to validate procedure creation and basic transaction flows, and observed successful completion of the smoke tests. 
- Verified that affected SQL `UPDATE` statements and client `UPDATE`/`INSERT` calls complete without runtime errors in the tested backends.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69919cd811e883249ae53a45f5ed78f0)