### PR TITLE
Add TPROC-H database version reporting

### DIFF
--- a/modules/jobs-1.0.tm
+++ b/modules/jobs-1.0.tm
@@ -2522,8 +2522,8 @@ proc wapp-page-jobs {} {
             wapp-subst {<h3 class="title">Job %html($jobid) %html($bm) Summary %html($tstamp)</h3>\n}
 
             wapp-subst {<table class="hdb-report-table" style="font-size: 150%;">\n}
-            wapp-subst {<tr><th>HDB</th><th>Database</th><th>Benchmark</th><th>Geomean</th><th>Query Time</th></tr>\n}
-            wapp-subst {<tr><td>%html($hdb_version)</td><td>%html($db)</td><td>%html($bm)</td><td><span class="hdb-nopm-value">%html($geo)</span></td><td>%html($qsetsummary)</td></tr>\n}
+            wapp-subst {<tr><th>HDB</th><th>Database</th><th>Release</th><th>Benchmark</th><th>Geomean</th><th>Query Time</th></tr>\n}
+            wapp-subst {<tr><td>%html($hdb_version)</td><td>%html($db)</td><td>%html($dbversion)</td><td>%html($bm)</td><td><span class="hdb-nopm-value">%html($geo)</span></td><td>%html($qsetsummary)</td></tr>\n}
             wapp-subst {</table>\n}
 
             jobs_summary_config_table $jobid "" $bm
@@ -3290,6 +3290,7 @@ if {$rawmode} {
     set db [join [hdbjobs eval {SELECT db FROM JOBMAIN WHERE JOBID=$jobid}]]
     set dbdisplay [jobs_database_display $db]
     set timestamp [join [hdbjobs eval {SELECT timestamp FROM JOBMAIN WHERE JOBID=$jobid}]]
+    # TPROC-C and TPROC-H workloads emit DBVersion markers consumed by get_dbversion for job.release.
     set dbversion [get_dbversion $jobid]
     set jobresult [getjobresult $jobid 1]
 

--- a/src/db2/db2olap.tcl
+++ b/src/db2/db2olap.tcl
@@ -1091,11 +1091,26 @@ proc sub_query { query_no scale_factor myposition } {
     }
     return $q2sub
 }
+proc CheckDBVersion { db_handle } {
+           if {[catch {set stmnt_handledbv [ db2_select_direct $db_handle "SELECT service_level from SYSIBMADM.ENV_INST_INFO" ]}]} {
+           set dbversion "DBVersion:NULL"
+           } else {
+            set dbversion [ db2_fetchrow $stmnt_handledbv ]
+            db2_finish $stmnt_handledbv
+	    regsub -all {DB2\ v} $dbversion "" dbversion
+            set dbversion "DBVersion:[join $dbversion]"
+           }
+           return "$dbversion"
+        }
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { dbname user password scale_factor RAISEERROR VERBOSE degree_of_parallel total_querysets myposition } {
     set db_handle [ ConnectToDb2 $dbname $user $password ]
     db2_exec_direct $db_handle "SET CURRENT DEGREE '$degree_of_parallel'"
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion $db_handle ]
+    }
 
     puts "Verifying the scale factor of the existing schema..."
     set countsql "SELECT count(*) FROM SUPPLIER"

--- a/src/mariadb/mariaolap.tcl
+++ b/src/mariadb/mariaolap.tcl
@@ -1239,11 +1239,23 @@ proc sub_query { query_no scale_factor myposition engine } {
     return $q2sub
 }
 
+proc CheckDBVersion { maria_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ maria::sel $maria_handler "select version()" -list ] ] - ] 0 ]}]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+		set dbversion "DBVersion:$dbversion"
+	   }
+	   return "$dbversion"
+	}
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { host port socket ssl_options user password db scale_factor RAISEERROR VERBOSE total_querysets myposition } {
     global mariastatus
     set maria_handler [ ConnectToMaria $host $port $socket $ssl_options $user $password $db ]
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion $maria_handler ]
+    }
     catch {mariaexec $maria_handler "SET SESSION use_stat_tables='PREFERABLY'"}
     puts "Verifying the scale factor of the existing schema..."
     set countsql "SELECT count(*) FROM SUPPLIER"

--- a/src/mssqlserver/mssqlsolap.tcl
+++ b/src/mssqlserver/mssqlsolap.tcl
@@ -1904,6 +1904,15 @@ proc sub_query { query_no scale_factor maxdop myposition } {
     }
     return $q2sub
 }
+proc CheckDBVersion { odbc } {
+	   if {[catch {set rows [ odbc allrows "SELECT SERVERPROPERTY('productversion')" ]} message ]} {
+		set dbversion "DBVersion:NULL"
+	   } else {
+	        set dbversion "DBVersion:[ lindex {*}$rows 1 ]"
+	   }
+	   return "$dbversion"
+	}
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { server port scale_factor odbc_driver authentication uid pwd tcp azure db encrypt trust_cert msi_object_id RAISEERROR VERBOSE maxdop total_querysets myposition} {
@@ -1913,6 +1922,9 @@ proc do_tpch { server port scale_factor odbc_driver authentication uid pwd tcp a
     } else {
         if {!$azure} {odbc evaldirect "use $db"}
         odbc evaldirect "set implicit_transactions OFF"
+    }
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion odbc ]
     }
 
     puts "Verifying the scale factor of the existing schema..."

--- a/src/mysql/mysqlolap.tcl
+++ b/src/mysql/mysqlolap.tcl
@@ -1451,12 +1451,24 @@ proc sub_query { query_no scale_factor myposition engine } {
     }
     return $q2sub
 }
+proc CheckDBVersion { mysql_handler } {
+           if {[catch {set dbversion [ lindex [ split [ list [ mysql::sel $mysql_handler "select version()" -list ] ] - ] 0 ]}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { host port socket ssl_options user password db scale_factor RAISEERROR VERBOSE total_querysets myposition mysql_tpch_obcompat ob_tenant_name} {
     global mysqlstatus
     set mysql_handler [ ConnectToMySQL $host $port $socket $ssl_options $user $password $db $mysql_tpch_obcompat $ob_tenant_name]
-    
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion $mysql_handler ]
+    }
+
     puts "Verifying the scale factor of the existing schema..."
     set countsql "SELECT count(*) FROM SUPPLIER"
     set count [ standsql $mysql_handler $countsql $RAISEERROR ]

--- a/src/oracle/oraolap.tcl
+++ b/src/oracle/oraolap.tcl
@@ -1422,12 +1422,30 @@ proc sub_query { query_no scale_factor myposition timesten } {
     }
     return $q2sub
 }
+proc CheckDBVersion { curn } {
+set dbversion ""
+    if {[catch {orasql $curn {select version from v$instance}}]} {
+	    set dbversion "DBVersion:NULL"
+    } else {
+        orafetch  $curn -datavariable output
+        while { [ oramsg  $curn ] == 0 } {
+            lappend dbversion $output
+            orafetch $curn -datavariable output
+        }
+        set dbversion "DBVersion:$dbversion"
+    }
+    return "$dbversion"
+}
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { connect  scale_factor RAISEERROR VERBOSE degree_of_parallel total_querysets timesten myposition } {
     set lda [ oralogon $connect ]
     if { !$timesten } { SetNLS $lda }
     set curn1 [ oraopen $lda ]
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion $curn1 ]
+    }
     if { !$timesten } {
         set sql(1) "alter session force parallel dml parallel (degree $degree_of_parallel)"
         set sql(2) "alter session force parallel ddl parallel (degree $degree_of_parallel)"

--- a/src/postgresql/pgolap.tcl
+++ b/src/postgresql/pgolap.tcl
@@ -1194,6 +1194,17 @@ proc sub_query { query_no scale_factor myposition } {
     }
     return $q2sub
 }
+proc CheckDBVersion { lda1 } {
+           if {[catch {pg_select $lda1 "select current_setting('server_version')" version_arr {
+                set dbversion $version_arr(current_setting)
+            }}]} {
+                set dbversion "DBVersion:NULL"
+           } else {
+                set dbversion "DBVersion:$dbversion"
+           }
+           return "$dbversion"
+        }
+
 #########################
 #TPCH QUERY SETS PROCEDURE
 proc do_tpch { host port sslmode db user password scale_factor RAISEERROR VERBOSE degree_of_parallel total_querysets myposition } {
@@ -1202,6 +1213,9 @@ proc do_tpch { host port sslmode db user password scale_factor RAISEERROR VERBOS
     set lda [ ConnectToPostgres $host $port $sslmode $user $password $db ]
     if { $lda eq "Failed" } {
         error "error, the database connection to $host could not be established"
+    }
+    if { $myposition <= 1 } {
+        puts [ CheckDBVersion $lda ]
     }
     set result [ pg_exec $lda "set max_parallel_workers_per_gather=$degree_of_parallel"]
     if {[pg_result $result -status] != "PGRES_COMMAND_OK"} {


### PR DESCRIPTION
### Motivation
- TPROC-H workloads did not emit the `DBVersion:<version>` marker the existing jobs module expects, so job summaries and the `summaryjson` artifact could miss the database release for TPROC-H runs.

### Description
- Added a database-specific `CheckDBVersion` proc to each TPROC‑H workload and emit it from the first/main virtual user path immediately after the connection is established for the following databases: `Oracle`, `SQL Server`, `Db2`, `PostgreSQL`, `MySQL`, and `MariaDB` (files changed: `src/oracle/oraolap.tcl`, `src/mssqlserver/mssqlsolap.tcl`, `src/db2/db2olap.tcl`, `src/postgresql/pgolap.tcl`, `src/mysql/mysqlolap.tcl`, `src/mariadb/mariaolap.tcl`).
- For each TPROC‑H workload the implementation mirrors the TPROC‑C approach for that database (queries used: Oracle `v$instance`, SQL Server `SERVERPROPERTY('productversion')`, Db2 `SYSIBMADM.ENV_INST_INFO`, PostgreSQL `current_setting('server_version')`, MySQL/MariaDB `select version()`).
- Emit the marker only for the primary path (checked `myposition <= 1` / first VU) using `puts [ CheckDBVersion ... ]` placed before scale‑factor verification, query execution, or timing starts in each `do_tpch` flow.
- Updated the web service TPROC‑H summary table to include a `Release` column and populated it from `get_dbversion` (`modules/jobs-1.0.tm`), and ensured `jobs_report_json` continues to populate `job.release` from `get_dbversion` so the JSON artifact contains the release when a `DBVersion:` marker is present.

### Testing
- Sourced each modified Tcl file with `tclsh` to verify no load/runtime syntax errors for `src/oracle/oraolap.tcl`, `src/mssqlserver/mssqlsolap.tcl`, `src/db2/db2olap.tcl`, `src/postgresql/pgolap.tcl`, `src/mysql/mysqlolap.tcl`, `src/mariadb/mariaolap.tcl`, and `modules/jobs-1.0.tm` (all succeeded).
- Ran `git diff --check` and repository search checks for `proc CheckDBVersion`, `puts [ CheckDBVersion`, and the jobs JSON/release paths to confirm the markers and summary changes were inserted as intended (all checks passed).
- Verified the TPROC‑H web summary table now includes `Release` and that `jobs_report_json` sets `release` from `get_dbversion` (manual code inspection/regex checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a202de7e1c4832489c0325846efe43a)