### PR TITLE
Add numberOfWHs and use it for TPC-C schema warehouse sizing

### DIFF
--- a/config/ci.xml
+++ b/config/ci.xml
@@ -8,6 +8,7 @@
             <diff_threshold>0.025</diff_threshold>
             <use_sudo>false</use_sudo>
             <ci_log_to_temp>1</ci_log_to_temp>
+            <warehouse_limit>4000</warehouse_limit>
             <root>/opt/hammerdb-ci</root>
             <tmp>/opt/hammerdb-ci/TMP</tmp>
     </common>

--- a/scripts/python/db2/tprocc/db2_tprocc_buildschema.py
+++ b/scripts/python/db2/tprocc/db2_tprocc_buildschema.py
@@ -10,7 +10,7 @@ diset ('connection','db2_def_pass','ibmdb2')
 diset('connection','db2_def_dbase','db2')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','db2_count_ware',warehouse)
 diset('tpcc','db2_num_vu',vu)
 diset('tpcc','db2_user','db2inst1')

--- a/scripts/python/maria/tprocc/maria_tprocc_buildschema.py
+++ b/scripts/python/maria/tprocc/maria_tprocc_buildschema.py
@@ -10,7 +10,7 @@ diset('connection','maria_port','3306')
 diset('connection','maria_socket','/tmp/mariadb.sock')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','maria_count_ware',warehouse)
 diset('tpcc','maria_num_vu',vu)
 diset('tpcc','maria_user','root')

--- a/scripts/python/mssqls/tprocc/mssqls_tprocc_buildschema.py
+++ b/scripts/python/mssqls/tprocc/mssqls_tprocc_buildschema.py
@@ -19,7 +19,7 @@ diset('connection','mssqls_uid','sa')
 diset('connection','mssqls_pass','admin')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','mssqls_count_ware',warehouse)
 diset('tpcc','mssqls_num_vu',vu)
 diset('tpcc','mssqls_dbase','tpcc')

--- a/scripts/python/mysql/tprocc/mysql_tprocc_buildschema.py
+++ b/scripts/python/mysql/tprocc/mysql_tprocc_buildschema.py
@@ -10,7 +10,7 @@ diset('connection','mysql_port','3306')
 diset('connection','mysql_socket','/tmp/mysql.sock')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','mysql_count_ware',warehouse)
 diset('tpcc','mysql_num_vu',vu)
 diset('tpcc','mysql_user','root')

--- a/scripts/python/oracle/tprocc/ora_tprocc_buildschema.py
+++ b/scripts/python/oracle/tprocc/ora_tprocc_buildschema.py
@@ -10,7 +10,7 @@ diset('connection','system_password','manager')
 diset('connection','instance','oracle')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','count_ware',warehouse)
 diset('tpcc','num_vu',vu)
 diset('tpcc','tpcc_user','tpcc')

--- a/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
+++ b/scripts/python/postgres/tprocc/pg_tprocc_buildschema.py
@@ -10,7 +10,7 @@ diset('connection','pg_port','5432')
 diset('connection','pg_sslmode','prefer')
 
 vu = tclpy.eval('numberOfCPUs')
-warehouse = int(vu) * 5
+warehouse = int(tclpy.eval('numberOfWHs'))
 diset('tpcc','pg_count_ware',warehouse)
 diset('tpcc','pg_num_vu',vu)
 diset('tpcc','pg_superuser','postgres')

--- a/scripts/tcl/db2/tprocc/db2_tprocc_buildschema.tcl
+++ b/scripts/tcl/db2/tprocc/db2_tprocc_buildschema.tcl
@@ -10,7 +10,7 @@ diset connection db2_def_pass ibmdb2
 diset connection db2_def_dbase db2
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc db2_count_ware $warehouse
 diset tpcc db2_num_vu $vu
 diset tpcc db2_user db2inst1

--- a/scripts/tcl/maria/tprocc/maria_tprocc_buildschema.tcl
+++ b/scripts/tcl/maria/tprocc/maria_tprocc_buildschema.tcl
@@ -10,7 +10,7 @@ diset connection maria_port 3306
 diset connection maria_socket /tmp/mariadb.sock
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc maria_count_ware $warehouse
 diset tpcc maria_num_vu $vu
 diset tpcc maria_user root

--- a/scripts/tcl/mssqls/tprocc/mssqls_tprocc_buildschema.tcl
+++ b/scripts/tcl/mssqls/tprocc/mssqls_tprocc_buildschema.tcl
@@ -19,7 +19,7 @@ diset connection mssqls_linux_authent sql
 diset connection mssqls_linux_odbc {ODBC Driver 18 for SQL Server}
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc mssqls_count_ware $warehouse
 diset tpcc mssqls_num_vu $vu
 diset tpcc mssqls_dbase tpcc

--- a/scripts/tcl/mysql/tprocc/mysql_tprocc_buildschema.tcl
+++ b/scripts/tcl/mysql/tprocc/mysql_tprocc_buildschema.tcl
@@ -10,7 +10,7 @@ diset connection mysql_port 3306
 diset connection mysql_socket /tmp/mysql.sock
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc mysql_count_ware $warehouse
 diset tpcc mysql_num_vu $vu
 diset tpcc mysql_user root

--- a/scripts/tcl/oracle/tprocc/ora_tprocc_buildschema.tcl
+++ b/scripts/tcl/oracle/tprocc/ora_tprocc_buildschema.tcl
@@ -10,7 +10,7 @@ diset connection system_password manager
 diset connection instance oracle
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc count_ware $warehouse
 diset tpcc num_vu $vu
 diset tpcc tpcc_user tpcc

--- a/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
+++ b/scripts/tcl/postgres/tprocc/pg_tprocc_buildschema.tcl
@@ -10,7 +10,7 @@ diset connection pg_port 5432
 diset connection pg_sslmode prefer
 
 set vu [ numberOfCPUs ]
-set warehouse [ expr {$vu * 5} ]
+set warehouse [ numberOfWHs ]
 diset tpcc pg_count_ware $warehouse
 diset tpcc pg_num_vu $vu
 diset tpcc pg_superuser postgres

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -426,8 +426,38 @@ proc numberOfWHs {} {
         set wh [ expr {int(ceil($wh / 1000.0)) * 1000} ]
     }
 
-    if {$wh > 4000} {
-        set wh 4000
+    set warehouse_limit 4000
+    global cidict
+    if {[info exists cidict] && [dict exists $cidict common warehouse_limit]} {
+        set ci_warehouse_limit [dict get $cidict common warehouse_limit]
+    } else {
+        set ci_warehouse_limit ""
+        if {[catch {set ISConfigDir [ file join  {*}[ lrange [ file split [ file normalize [ file dirname [ info script ] ]]] 0 end-2 ] config ]}]} { set ISConfigDir "" }
+        if {[info exists argv0]} {
+            set AGConfigDir [ file join  {*}[ file split [ file normalize [ file dirname $argv0 ]]] config ]
+        } else {
+            set AGConfigDir .
+        }
+        set PWConfigDir [ file join [ pwd ] config ]
+        foreach CD {ISConfigDir AGConfigDir PWConfigDir} {
+            set cixml [ file join [ set $CD ] ci.xml ]
+            if {[ file readable $cixml ]} {
+                if {![catch {open $cixml r} ci_fd]} {
+                    set ci_xml [read $ci_fd]
+                    close $ci_fd
+                    if {[regexp {<warehouse_limit>([^<]+)</warehouse_limit>} $ci_xml -> ci_warehouse_limit]} {
+                        break
+                    }
+                }
+            }
+        }
+    }
+    if {[string is integer -strict $ci_warehouse_limit] && $ci_warehouse_limit >= 1} {
+        set warehouse_limit $ci_warehouse_limit
+    }
+
+    if {$wh > $warehouse_limit} {
+        set wh $warehouse_limit
     }
 
     return $wh

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -415,45 +415,24 @@ proc numberOfCPUs {} {
 }
 
 proc numberOfWHs {} {
-    set vu [ numberOfCPUs ]
-    set wh [ expr {$vu * 10} ]
-
-    if {$wh <= 100} {
-        set wh [ expr {int(ceil($wh / 10.0)) * 10} ]
-    } elseif {$wh <= 1000} {
-        set wh [ expr {int(ceil($wh / 100.0)) * 100} ]
-    } else {
-        set wh [ expr {int(ceil($wh / 1000.0)) * 1000} ]
-    }
-
     set warehouse_limit 4000
+
     global cidict
     if {[info exists cidict] && [dict exists $cidict common warehouse_limit]} {
-        set ci_warehouse_limit [dict get $cidict common warehouse_limit]
-    } else {
-        set ci_warehouse_limit ""
-        if {[catch {set ISConfigDir [ file join  {*}[ lrange [ file split [ file normalize [ file dirname [ info script ] ]]] 0 end-2 ] config ]}]} { set ISConfigDir "" }
-        if {[info exists argv0]} {
-            set AGConfigDir [ file join  {*}[ file split [ file normalize [ file dirname $argv0 ]]] config ]
-        } else {
-            set AGConfigDir .
-        }
-        set PWConfigDir [ file join [ pwd ] config ]
-        foreach CD {ISConfigDir AGConfigDir PWConfigDir} {
-            set cixml [ file join [ set $CD ] ci.xml ]
-            if {[ file readable $cixml ]} {
-                if {![catch {open $cixml r} ci_fd]} {
-                    set ci_xml [read $ci_fd]
-                    close $ci_fd
-                    if {[regexp {<warehouse_limit>([^<]+)</warehouse_limit>} $ci_xml -> ci_warehouse_limit]} {
-                        break
-                    }
-                }
-            }
+        set configured_limit [dict get $cidict common warehouse_limit]
+        if {[string is integer -strict $configured_limit] && $configured_limit >= 1} {
+            set warehouse_limit $configured_limit
         }
     }
-    if {[string is integer -strict $ci_warehouse_limit] && $ci_warehouse_limit >= 1} {
-        set warehouse_limit $ci_warehouse_limit
+
+    set wh [expr {[numberOfCPUs] * 10}]
+
+    if {$wh <= 100} {
+        set wh [expr {int(ceil($wh / 10.0)) * 10}]
+    } elseif {$wh <= 1000} {
+        set wh [expr {int(ceil($wh / 100.0)) * 100}]
+    } else {
+        set wh [expr {int(ceil($wh / 1000.0)) * 1000}]
     }
 
     if {$wh > $warehouse_limit} {

--- a/src/generic/gencli.tcl
+++ b/src/generic/gencli.tcl
@@ -414,6 +414,25 @@ proc numberOfCPUs {} {
   return 1
 }
 
+proc numberOfWHs {} {
+    set vu [ numberOfCPUs ]
+    set wh [ expr {$vu * 10} ]
+
+    if {$wh <= 100} {
+        set wh [ expr {int(ceil($wh / 10.0)) * 10} ]
+    } elseif {$wh <= 1000} {
+        set wh [ expr {int(ceil($wh / 100.0)) * 100} ]
+    } else {
+        set wh [ expr {int(ceil($wh / 1000.0)) * 1000} ]
+    }
+
+    if {$wh > 4000} {
+        set wh 4000
+    }
+
+    return $wh
+}
+
 proc vuset { args } {
     global virtual_users conpause delayms ntimes suppo optlog unique_log_name no_log_buffer log_timestamps opmode
     upvar #0 genericdict genericdict


### PR DESCRIPTION
### Motivation

- Replace the previous simple `vu * 5` heuristic for computing TPC-C warehouse counts with a dedicated function to improve scaling behavior and enforce sensible rounding and caps.
- Centralize warehouse-sizing logic so all DB-specific buildschema scripts use the same calculation and limits.
- Prevent overly large warehouse counts by introducing an upper bound and tiered rounding rules.

### Description

- Added a new procedure `numberOfWHs` to `src/generic/gencli.tcl` which computes warehouses from `numberOfCPUs` using `vu * 10`, rounds to 10/100/1000 buckets depending on size, and caps the result at `4000` before returning it.
- Updated TPC-C schema build scripts (both Tcl and embedded Tcl in Python wrappers) for DBs `db2`, `maria`, `mssqls`, `mysql`, `ora`/`oracle`, and `pg`/`postgres` to call `numberOfWHs` instead of calculating `vu * 5` locally and to set the appropriate `tpcc` count variables via `diset`.
- Kept existing partition threshold checks and `buildschema` invocation behavior unchanged, only swapping the warehouse value source.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a203ca4faa88324a4e0206d97949764)