### PR TITLE
Use blocking reads for CI ping checks

### DIFF
--- a/src/mariadb/mariaci.tcl
+++ b/src/mariadb/mariaci.tcl
@@ -1132,22 +1132,33 @@ proc mariadb_ping {cidict refname} {
 
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_mariadb_ping_output ""
-        set ::pipe_done 0
         set close_status OK
+        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
-            set pipe [open "|bash -c \"cd $basedir && $sql_cmd\"" "r"]
-            fconfigure $pipe -blocking 0 -buffering line
-            fileevent $pipe readable [list _mariadb_ping_capture $pipe]
-            after 3000 { if {$::pipe_done == 0} { set ::pipe_done 1 } }
-            vwait ::pipe_done
-            if {[catch {close $pipe} errMsg]} { set close_status $errMsg }
+            set pipe [open "|bash -c {$cmd}" "r"]
+            fconfigure $pipe -blocking 1
+            set ::_mariadb_ping_output [read $pipe]
+            if {[catch {close $pipe} errMsg]} {
+                set close_status $errMsg
+            }
         } errMsg]} {
             set close_status $errMsg
         }
 
-        if {$close_status eq "OK" && [string trim $::_mariadb_ping_output] ne ""} {
+        set output_trim [string trim [string map {\r ""} $::_mariadb_ping_output]]
+        if {$close_status eq "OK" && [regexp -nocase {[0-9]+(\.[0-9]+)+.*mariadb} $output_trim]} {
+            foreach line [split $output_trim "\n"] {
+                putsci $line
+            }
             return "PING SUCCEEDED"
+        }
+
+        putsci "PING attempt $attempt failed"
+        putsci "PING close_status: $close_status"
+        putsci "PING output:"
+        foreach line [split $output_trim "\n"] {
+            putsci $line
         }
 
         if {$attempt < $attempts} {
@@ -1156,7 +1167,6 @@ proc mariadb_ping {cidict refname} {
     }
 
     putsci "PING FAILED: no version returned"
-    putsci $::_mariadb_ping_output
     return "PING FAILED"
 }
 

--- a/src/mariadb/mariaci.tcl
+++ b/src/mariadb/mariaci.tcl
@@ -1133,17 +1133,19 @@ proc mariadb_ping {cidict refname} {
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_mariadb_ping_output ""
         set close_status OK
-        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
+            set cmd "cd \"$basedir\" && $sql_cmd 2>&1"
             set pipe [open "|bash -c {$cmd}" "r"]
             fconfigure $pipe -blocking 1
             set ::_mariadb_ping_output [read $pipe]
+
             if {[catch {close $pipe} errMsg]} {
                 set close_status $errMsg
             }
         } errMsg]} {
             set close_status $errMsg
+            set ::_mariadb_ping_output $errMsg
         }
 
         set output_trim [string trim [string map {\r ""} $::_mariadb_ping_output]]

--- a/src/mysql/mysqlci.tcl
+++ b/src/mysql/mysqlci.tcl
@@ -1158,22 +1158,33 @@ proc mysql_ping {cidict refname} {
 
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_mysql_ping_output ""
-        set ::pipe_done 0
         set close_status OK
+        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
-            set pipe [open "|bash -c \"cd $basedir && $sql_cmd\"" "r"]
-            fconfigure $pipe -blocking 0 -buffering line
-            fileevent $pipe readable [list _mysql_ping_capture $pipe]
-            after 3000 { if {$::pipe_done == 0} { set ::pipe_done 1 } }
-            vwait ::pipe_done
-            if {[catch {close $pipe} errMsg]} { set close_status $errMsg }
+            set pipe [open "|bash -c {$cmd}" "r"]
+            fconfigure $pipe -blocking 1
+            set ::_mysql_ping_output [read $pipe]
+            if {[catch {close $pipe} errMsg]} {
+                set close_status $errMsg
+            }
         } errMsg]} {
             set close_status $errMsg
         }
 
-        if {$close_status eq "OK" && [string trim $::_mysql_ping_output] ne ""} {
+        set output_trim [string trim [string map {\r ""} $::_mysql_ping_output]]
+        if {$close_status eq "OK" && [regexp {[0-9]+(\.[0-9]+)+} $output_trim]} {
+            foreach line [split $output_trim "\n"] {
+                putsci $line
+            }
             return "PING SUCCEEDED"
+        }
+
+        putsci "PING attempt $attempt failed"
+        putsci "PING close_status: $close_status"
+        putsci "PING output:"
+        foreach line [split $output_trim "\n"] {
+            putsci $line
         }
 
         if {$attempt < $attempts} {
@@ -1182,7 +1193,6 @@ proc mysql_ping {cidict refname} {
     }
 
     putsci "PING FAILED: no version returned"
-    putsci $::_mysql_ping_output
     return "PING FAILED"
 }
 

--- a/src/mysql/mysqlci.tcl
+++ b/src/mysql/mysqlci.tcl
@@ -1159,17 +1159,19 @@ proc mysql_ping {cidict refname} {
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_mysql_ping_output ""
         set close_status OK
-        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
+            set cmd "cd \"$basedir\" && $sql_cmd 2>&1"
             set pipe [open "|bash -c {$cmd}" "r"]
             fconfigure $pipe -blocking 1
             set ::_mysql_ping_output [read $pipe]
+
             if {[catch {close $pipe} errMsg]} {
                 set close_status $errMsg
             }
         } errMsg]} {
             set close_status $errMsg
+            set ::_mysql_ping_output $errMsg
         }
 
         set output_trim [string trim [string map {\r ""} $::_mysql_ping_output]]

--- a/src/postgresql/pgci.tcl
+++ b/src/postgresql/pgci.tcl
@@ -970,17 +970,19 @@ proc postgresql_ping {cidict refname} {
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_postgresql_ping_output ""
         set close_status OK
-        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
+            set cmd "cd \"$basedir\" && $sql_cmd 2>&1"
             set pipe [open "|bash -c {$cmd}" "r"]
             fconfigure $pipe -blocking 1
             set ::_postgresql_ping_output [read $pipe]
+
             if {[catch {close $pipe} errMsg]} {
                 set close_status $errMsg
             }
         } errMsg]} {
             set close_status $errMsg
+            set ::_postgresql_ping_output $errMsg
         }
 
         set output_trim [string trim [string map {\r ""} $::_postgresql_ping_output]]

--- a/src/postgresql/pgci.tcl
+++ b/src/postgresql/pgci.tcl
@@ -969,22 +969,33 @@ proc postgresql_ping {cidict refname} {
 
     for {set attempt 1} {$attempt <= $attempts} {incr attempt} {
         set ::_postgresql_ping_output ""
-        set ::pipe_done 0
         set close_status OK
+        set cmd "cd $basedir && { $sql_cmd; } 2>&1"
 
         if {[catch {
-            set pipe [open "|bash -c \"cd $basedir && $sql_cmd\"" "r"]
-            fconfigure $pipe -blocking 0 -buffering line
-            fileevent $pipe readable [list _postgresql_ping_capture $pipe]
-            after 3000 { if {$::pipe_done == 0} { set ::pipe_done 1 } }
-            vwait ::pipe_done
-            if {[catch {close $pipe} errMsg]} { set close_status $errMsg }
+            set pipe [open "|bash -c {$cmd}" "r"]
+            fconfigure $pipe -blocking 1
+            set ::_postgresql_ping_output [read $pipe]
+            if {[catch {close $pipe} errMsg]} {
+                set close_status $errMsg
+            }
         } errMsg]} {
             set close_status $errMsg
         }
 
-        if {$close_status eq "OK" && [string trim $::_postgresql_ping_output] ne ""} {
+        set output_trim [string trim [string map {\r ""} $::_postgresql_ping_output]]
+        if {$close_status eq "OK" && [regexp -nocase {postgresql} $output_trim]} {
+            foreach line [split $output_trim "\n"] {
+                putsci $line
+            }
             return "PING SUCCEEDED"
+        }
+
+        putsci "PING attempt $attempt failed"
+        putsci "PING close_status: $close_status"
+        putsci "PING output:"
+        foreach line [split $output_trim "\n"] {
+            putsci $line
         }
 
         if {$attempt < $attempts} {
@@ -993,7 +1004,6 @@ proc postgresql_ping {cidict refname} {
     }
 
     putsci "PING FAILED: no version returned"
-    putsci $::_postgresql_ping_output
     return "PING FAILED"
 }
 


### PR DESCRIPTION
### Motivation
- The existing async `fileevent`/`vwait` pipe capture for MariaDB/MySQL/PostgreSQL pings was unreliable and could miss later-ready outputs. 
- Ping is a simple readiness check and must block until the client command produces complete output, including `stderr`, to avoid false failures. 
- Keep the existing retry behavior and the version-check SQL to preserve CI evidence of the started database.

### Description
- Replace the non-blocking `fileevent`/`vwait` capture with a blocking `open "|bash -c {$cmd}" "r"`, `fconfigure -blocking 1` and `read $pipe` pattern and capture `2>&1` for stderr in `mariadb_ping`, `mysql_ping`, and `postgresql_ping`. 
- Trim CRs, split the captured output and emit it line-by-line via `putsci` to preserve CI log formatting, and log failed attempts with attempt number, `close_status`, and the per-line output. 
- Require positive version checks before treating output as success using DB-appropriate regexes (MariaDB, MySQL generic version, PostgreSQL). 
- Keep the existing retry loop (`set attempts 30` and `set wait_ms 2000`) and leave unrelated start/shutdown/build/test logic unchanged; changes are limited to the three ping procs in `src/mariadb/mariaci.tcl`, `src/mysql/mysqlci.tcl`, and `src/postgresql/pgci.tcl`.

### Testing
- Sourced each modified file with `tclsh` to validate Tcl syntax and loading, and each file reported `OK` when sourced. (succeeded)
- Ran a small standalone Tcl script that opens a blocking pipe and `read`s output to verify the blocking-read pattern behaves as expected (succeeded).
- Ran `git diff --check` and basic repository checks after the changes (no issues found). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e94293b883249aa5eea93d601970)