### PR TITLE
Fix CI ping SQL quoting

### DIFF
--- a/src/mariadb/mariaci.tcl
+++ b/src/mariadb/mariaci.tcl
@@ -1122,7 +1122,7 @@ proc mariadb_ping {cidict refname} {
     if {[dict exists $cidict $rdbms ping]} {
         set sql [string trim [dict get $cidict $rdbms ping]]
     }
-    set sql_cmd "./bin/mariadb -S $socket --skip-ssl -vvv -e \\\"$sql\\\""
+    set sql_cmd "./bin/mariadb -S $socket --skip-ssl -vvv -e \"$sql\""
 
     putsci "PING:"
     putsci $sql_cmd

--- a/src/mysql/mysqlci.tcl
+++ b/src/mysql/mysqlci.tcl
@@ -1148,7 +1148,7 @@ proc mysql_ping {cidict refname} {
         set sql [string trim [dict get $cidict $rdbms ping]]
     }
     set cli "./bin/mysql -S $socket --ssl-mode=DISABLED -u root"
-    set sql_cmd "$cli -vvv -e \\\"$sql\\\" || $cli -pmysql -vvv -e \\\"$sql\\\""
+    set sql_cmd "$cli -vvv -e \"$sql\" || $cli -pmysql -vvv -e \"$sql\""
 
     putsci "PING:"
     putsci $sql_cmd

--- a/src/postgresql/pgci.tcl
+++ b/src/postgresql/pgci.tcl
@@ -959,7 +959,7 @@ proc postgresql_ping {cidict refname} {
         set sql [string trim [dict get $install ping]]
     }
     set sql_esc [string map {\" \\\"} $sql]
-    set sql_cmd "./bin/psql -h localhost -p $port -U postgres -d postgres -t -c \\\"$sql_esc\\\""
+    set sql_cmd "./bin/psql -h localhost -p $port -U postgres -d postgres -t -c \"$sql_esc\""
 
     putsci "PING:"
     putsci $sql_cmd


### PR DESCRIPTION
### Motivation
- The blocking ping wrapper capture was kept, but the SQL argument quoting was accidentally escaped so literal backslash-quoted strings reached DB clients and caused errors; the change restores the original behavior so the client receives the query as a single argument.

### Description
- Updated the `sql_cmd` construction in the ping procedures to use normal shell quoting so the SQL is passed as a single quoted argument: `src/mariadb/mariaci.tcl` (`mariadb_ping`), `src/mysql/mysqlci.tcl` (`mysql_ping`), and `src/postgresql/pgci.tcl` (`postgresql_ping`).
- For MariaDB: changed `-e \"$sql\"` to `-e "$sql"`.
- For MySQL: changed `-e \"$sql\"` to `-e "$sql"` (both passwordless and `-pmysql` fallback). 
- For PostgreSQL: changed `-c \"$sql_esc\"` to `-c "$sql_esc"` and left the existing `sql_esc` mapping intact.
- Preserved the blocking `bash -c` wrapper, `fconfigure -blocking 1`, `read $pipe`, and all other ping retry and success-check logic.

### Testing
- Ran `git diff --check` and the check succeeded.
- Verified the updated `set sql_cmd` lines and that the blocking-read pattern (`open "|bash -c {$cmd}"`, `fconfigure $pipe -blocking 1`, and `read $pipe`) remain present using `rg`, and the verifications succeeded.
- Confirmed the three files were modified as intended and no other ping logic was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a230ca895f08324b6098f649fbf7449)